### PR TITLE
Remove padding and use ProductName from vtex.storecomponents.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Add _ProductDescription_ Component and savings information in _Price_ Component.
 
+### Fixed
+
+* Remove padding and use _ProductName_ from `vtex.storecomponents`.
+
 ## [0.0.2] - 2018-05-10
 
 ### Fixed

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -5,8 +5,8 @@ import { graphql } from 'react-apollo'
 
 import BuyButton from 'vtex.storecomponents/BuyButton'
 import ProductDescription from 'vtex.storecomponents/ProductDescription'
+import ProductName from 'vtex.storecomponents/ProductName'
 
-import { ProductName } from '@vtex/product-details'
 import Spinner from '@vtex/styleguide/lib/Spinner'
 
 import Price from './Price'

--- a/react/product-details.css
+++ b/react/product-details.css
@@ -6,10 +6,6 @@
 @custom-media --breakpoint-extra-large screen and (min-width: 80em); */
 
 @media screen and (min-width: 20em) {
-  .vtex-product-details {
-    padding-top: 150px;
-  }
-
   .vtex-product-details__name-container .vtex-product-name__brand {
     font-size: 1.5rem;
   }
@@ -21,10 +17,6 @@
 }
 
 @media screen and (min-width: 40em) {
-  .vtex-product-details {
-    padding-top: 90px;
-  }
-
   .vtex-product-details__name-container .vtex-product-name__brand {
     font-size: 2.25rem;
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Remove padding and use ProductName from vtex.storecomponents.

#### What problem is this solving?

The component should,'t handle the padding

#### How should this be manually tested?

[Access the workspace](https://details--storecomponents.myvtex.com/ninja-300/p)

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
