### PR TITLE
Fix responsivity of mobile product images

### DIFF
--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -36,15 +36,11 @@ class ProductDetails extends Component {
       <div className="vtex-product-details flex flex-wrap ph6">
         <div className="vtex-product-details__images-container w-50-ns w-100-s pr5-ns">
           <div className="fr-ns w-100 h-100">
-            {/* FIXME: Change when ProductImages become stable */}
-            <div className="dn-s db-l">
+            <div className="db">
               <ProductImages
                 images={selectedItem.images}
                 thumbnailSliderOrientation="HORIZONTAL"
               />
-            </div>
-            <div className="db-s dn-ns bg-silver tc w-100 h-100">
-              Product Images
             </div>
           </div>
         </div>

--- a/react/ProductImages.js
+++ b/react/ProductImages.js
@@ -53,7 +53,7 @@ class ProductImages extends Component {
 
     return (
       <div className={className}>
-        {images.length > 1 && <ThumbnailSlider {...thumbnailProps} />}
+        <ThumbnailSlider {...thumbnailProps} />
         <SelectedImage image={this.state.selectedImage} />
       </div>
     )

--- a/react/components/SelectedImage.js
+++ b/react/components/SelectedImage.js
@@ -12,8 +12,8 @@ class SelectedImage extends Component {
     const { imageUrl, imageText } = this.props.image
 
     return (
-      <div className={`${VTEXClasses.SELECTED_IMAGE} dn di-ns`}>
-        <img className="mw-100 mh-100" src={imageUrl} alt={imageText} />
+      <div className={`${VTEXClasses.SELECTED_IMAGE} dn db-ns`}>
+        <img src={imageUrl} alt={imageText} />
       </div>
     )
   }

--- a/react/components/ThumbnailItem.js
+++ b/react/components/ThumbnailItem.js
@@ -21,7 +21,7 @@ class ThumbnailItem extends Component {
 
     return (
       <div className={VTEXClasses.THUMBNAIL_ITEM} onClick={this.handleClick}>
-        <img className="mw-100 mh-100" src={imageUrl} alt={imageText} />
+        <img src={imageUrl} alt={imageText} />
       </div>
     )
   }

--- a/react/constants/productImagesClasses.js
+++ b/react/constants/productImagesClasses.js
@@ -4,8 +4,7 @@ export default {
   HORIZONTAL_COMPONENT: 'vtex-product-image__horizontal',
   SELECTED_IMAGE: 'vtex-product-image__selected-image',
   VERTICAL_THUMBNAIL_SLIDER: 'vtex-product-image__vertical-thumbnail-slider',
-  HORIZONTAL_THUMBNAIL_SLIDER:
-    'vtex-product-image__horizontal-thumbnail-slider',
+  HORIZONTAL_THUMBNAIL_SLIDER: 'vtex-product-image__horizontal-thumbnail-slider',
   THUMBNAIL_ITEM: 'vtex-product-image__thumbnail-slider-item',
   VERTICAL_ARROW_PREV: 'vtex-product-image__vertical-arrow--prev',
   VERTICAL_ARROW_NEXT: 'vtex-product-image__vertical-arrow--next',

--- a/react/global.css
+++ b/react/global.css
@@ -1,4 +1,4 @@
 @import url('~slick-carousel/slick/slick.css');
 @import url('~slick-carousel/slick/slick-theme.css');
 @import url('product-details.css');
-@import url('product-image.css');
+@import url('product-images.css');

--- a/react/product-images.css
+++ b/react/product-images.css
@@ -1,45 +1,34 @@
-.vtex-product-image .vtex-product-image__horizontal {
-  width: 500px;
+/* 
+@custom-media --breakpoint-small screen and (min-width: 20em);
+@custom-media --breakpoint-not-small screen and (min-width: 40em);
+@custom-media --breakpoint-medium screen and (min-width: 40em) and (max-width: 64em);
+@custom-media --breakpoint-large screen and (min-width: 64em) and (max-width: 80em);
+@custom-media --breakpoint-extra-large screen and (min-width: 80em); 
+*/
+
+.vtex-product-image__thumbnail-slider-item {
+  max-width: 100%;
 }
 
-.vtex-product-image .vtex-product-image__vertical {
-  width: 600px;
+.vtex-product-image__vertical {
+  max-width: 325px;
 }
 
-/* Selected Image */
-.vtex-product-image .vtex-product-image__selected-image {
-  width: 500px;
-  height: 500px;
+.vtex-product-image__horizontal {
+  max-width: 325px;
 }
 
-/* Thumbnail Slider */
-.vtex-product-image .vtex-product-image__horizontal-thumbnail-slider,
-.vtex-product-image .vtex-product-image__vertical-thumbnail-slider {
-  width: 100%;
-  height: 100%;
-}
-
-@media (min-width: 700px) {
-  .vtex-product-image .vtex-product-image__vertical-thumbnail-slider {
-    width: 100px;
-    height: 500px;
+@media only screen and (min-width: 40em) {
+  .vtex-product-image__vertical {
+    max-width: 100%;
   }
 
-  .vtex-product-image .vtex-product-image__horizontal-thumbnail-slider {
-    width: 500px;
-    height: 100px;
+  .vtex-product-image__horizontal {
+    max-width: 100%;
   }
-}
 
-/* Thumbnail Slider Item */
-.vtex-product-image .vtex-product-image__thumbnail-slider-item {
-  width: 100%;
-}
-
-@media (min-width: 700px) {
-  .vtex-product-image .vtex-product-image__thumbnail-slider-item {
-    width: 100px;
-    height: 100px;
+  .vtex-product-image__thumbnail-slider-item img {
+    max-width: 100px;
   }
 }
 
@@ -82,6 +71,10 @@
 /* Dots */
 .vtex-product-image .vtex-product-image__dots li button {
   color: inherit;
+}
+
+.vtex-product-image .vtex-product-image__dots {
+  margin-bottom: 20px;
 }
 
 .vtex-product-image .vtex-product-image__dots li button:before {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adding the responsive behavior for mobile product details without changing the non mobile behavior.

#### What problem is this solving?
Fix the responsivity problem of mobile product details.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

[Workspace](https://product-images--storecomponents.myvtex.com/)

![screenshot from 2018-05-12 09-34-14](https://user-images.githubusercontent.com/9275109/39957335-c86a517e-55c7-11e8-885a-4afc15538bfa.png)
![screenshot from 2018-05-12 09-34-48](https://user-images.githubusercontent.com/9275109/39957338-cc0e3c8c-55c7-11e8-948c-9e26df6ff614.png)
![screenshot from 2018-05-12 09-34-05](https://user-images.githubusercontent.com/9275109/39957342-d3d096fe-55c7-11e8-98b9-78c31dc7ff19.png)
![screenshot from 2018-05-12 09-34-53](https://user-images.githubusercontent.com/9275109/39957343-d6a40abe-55c7-11e8-9842-e283110ebb0e.png)


#### Types of changes
CSS Media queries changes.

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
