### PR TITLE
Remove is required property from images of product details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.0.5] - 2018-05-12
+### Fixed
+- Fix warning of required properties on images of product details
+
 ## [0.0.4] - 2018-05-12
 ### Fixed
 - Fix responsivity of mobile product images

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -116,9 +116,9 @@ class ProductDetails extends Component {
                 /** Image id */
                 imageId: PropTypes.string.isRequired,
                 /** Image label */
-                imageLabel: PropTypes.string.isRequired,
+                imageLabel: PropTypes.string,
                 /** Image tag as string */
-                imageTag: PropTypes.string.isRequired,
+                imageTag: PropTypes.string,
                 /** Image URL */
                 imageUrl: PropTypes.string.isRequired,
                 /** Image text */


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix warning of required prop on product details page.

<!--- Describe your changes in detail. -->

#### What problem is this solving?
Fix warning of required prop on product details page.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
