### PR TITLE
Fix product images updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `ProductImages` component not updating selected image when props changed.
 
 ## [0.0.5] - 2018-05-12
 ### Fixed

--- a/react/ProductImages.js
+++ b/react/ProductImages.js
@@ -14,10 +14,13 @@ const DEFAULT_SELECTED_IMAGE = 0
  *  Display a list of thumbnail images in a slider and a main image of a product.
  */
 class ProductImages extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      selectedImage: this.props.images[DEFAULT_SELECTED_IMAGE],
+  state = {
+    selectedImage: this.props.images[DEFAULT_SELECTED_IMAGE],
+  }
+
+  static getDerivedStateFromProps(nextProps) {
+    return {
+      selectedImage: nextProps.images[DEFAULT_SELECTED_IMAGE],
     }
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add method to `ProductImages` to update state from next props.

#### What problem is this solving?
Fix the `ProductImages` component not updating the selected image when props were updated.

#### How should this be manually tested?
[Access the workspace](https://productdetails--storecomponents.myvtex.com/ninja-300/p).

#### Screenshots or example usage
N/A

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
