### PR TITLE
Fix the loading in the product page for it be in center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Update the spinner to be in the center.
+
 ## [0.0.6] - 2018-05-14
 ### Fixed
 - `ProductImages` component not updating selected image when props changed.

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -21,10 +21,8 @@ class ProductDetails extends Component {
     const { product } = this.props.data
     if (!product) {
       return (
-        <div className="w-100 flex justify-center">
-          <div className="w-10">
-            <Spinner />
-          </div>
+        <div className="pt6 tc">
+          <Spinner />
         </div>
       )
     }
@@ -33,7 +31,7 @@ class ProductDetails extends Component {
     const { commertialOffer } = selectedItem.sellers[0]
 
     return (
-      <div className="vtex-product-details flex flex-wrap ph6">
+      <div className="vtex-product-details flex flex-wrap pa6">
         <div className="vtex-product-details__images-container w-50-ns w-100-s pr5-ns">
           <div className="fr-ns w-100 h-100">
             <div className="db">


### PR DESCRIPTION
#### What is the purpose of this pull request?

Updating the loading in the product pages to be in the center.

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
https://loadingfix--storecomponents.myvtex.com/

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [X] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
