### PR TITLE
Integrate `vtex.storecomponents/TechnicalSpecifications` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Integrate with `vtex.storecomponents/TechnicalSpecifications`.
 
 ## [0.1.0] - 2018-05-21
 ### Added

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -9,6 +9,7 @@ import ProductName from 'vtex.storecomponents/ProductName'
 import Price from 'vtex.storecomponents/ProductPrice'
 import ProductImages from 'vtex.storecomponents/ProductImages'
 import ShippingSimulator from 'vtex.storecomponents/ShippingSimulator'
+import TechnicalSpecifications from 'vtex.storecomponents/TechnicalSpecifications'
 
 import Spinner from '@vtex/styleguide/lib/Spinner'
 
@@ -87,6 +88,9 @@ class ProductDetails extends Component {
           <ProductDescription>
             <span className="measure-wide">{product.description}</span>
           </ProductDescription>
+        </div>
+        <div className="vtex-product-details__technical-specifications-container w-100">
+          <TechnicalSpecifications specifications={product.properties} skuName={selectedItem.name} />
         </div>
       </div>
     )

--- a/react/graphql/productQuery.gql
+++ b/react/graphql/productQuery.gql
@@ -25,5 +25,9 @@ query Product($slug: String) {
         }
       }
     }
+    properties {
+      name
+      values
+    }
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add the `TechnicalSpecifications` component to the product details page.

#### What problem is this solving?
The component wasn't implemented yet.

#### How should this be manually tested?
[Access the workspace](https://technicalspecifications--storecomponents.myvtex.com/samsung-s9/p)

#### Screenshots or example usage
![screenshot-2018-5-22 https technicalspecifications--storecomponents myvtex com 1](https://user-images.githubusercontent.com/10223856/40381087-2c7d7270-5dd1-11e8-86c9-f05f1caa6f53.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
