### PR TITLE
Fix compare sku function not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update props passed to `ShippingSimulator`.
 - Sku items sorted by price.
 
-#Fixed
+###Fixed
 - Compare sku function not found.
 
 ## [0.2.0] - 2018-05-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update props passed to `ShippingSimulator`.
 - Sku items sorted by price.
 
+#Fixed
+- Compare sku function not found.
+
 ## [0.2.0] - 2018-05-29
 ### Changed
 - Requesting ProductReference info from product and passing it to `vtex.store-components/ProductName`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update props passed to `ShippingSimulator`.
 - Sku items sorted by price.
 
-###Fixed
+### Fixed
 - Compare sku function not found.
 
 ## [0.2.0] - 2018-05-29

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -40,7 +40,7 @@ class ProductDetails extends Component {
     }
 
     let skuItems = product.items.slice()
-    skuItems.sort(this.compareSku)
+    skuItems.sort(compareSku)
 
     const selectedItem = skuItems[this.state.skuIndex]
     const { commertialOffer } = selectedItem.sellers[0]
@@ -142,7 +142,7 @@ const options = {
   }),
 }
 
-compareSku = (item1, item2) => {
+const compareSku = (item1, item2) => {
   if (item1.sellers[0].commertialOffer.AvailableQuantity === 0) {
     return 1
   } else if (item2.sellers[0].commertialOffer.AvailableQuantity === 0) {


### PR DESCRIPTION
#### What is the purpose of this pull request?
The compare sku function not found.

#### What problem is this solving?
There was an error because this method wasn't found.

#### How should this be manually tested?
https://waza--storecomponents.myvtex.com

#### Screenshots or example usage

#### Types of changes

* [X] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
