### PR TITLE
Add ProductPrice schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `AvailabilitySubscriber`component.
 - Add `SkuSelector` and `Share` components.
 - Add a schema to the `ProductDetails` Component.
+- Add `ProductPrice` schema to the `ProductDetails` schema.
 
 ### Changed
 - Update props passed to `ShippingSimulator`.

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -112,10 +112,7 @@ class ProductDetails extends Component {
                   listPrice={commertialOffer.ListPrice}
                   sellingPrice={commertialOffer.Price}
                   installments={commertialOffer.Installments}
-                  showListPrice
-                  showLabels
-                  showInstallments
-                  showSavings
+                  {...this.props.price}
                 />
               </div>
             )}


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add ProductPrice schema to the ProductDetails schema.

https://github.com/vtex-apps/store-components/pull/87

#### What problem is this solving?

No way to configure ProductPrice Component

#### How should this be manually tested?

[Access the workspace](https://share--storecomponents.myvtex.com/nintendo-switch/p) and edit the ProductDetails schema

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/41102779-04ae1cda-6a3e-11e8-91e9-b665562c1223.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
