### PR TITLE
Use description as prop instead of children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Pass description as prop instead of children.
 
 ## [0.4.0] - 2018-6-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.4.1] - 2018-7-6
 ### Changed
 - Pass description as prop instead of children.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "product-details",
   "vendor": "vtex",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "title": "Product Details",
   "description": "Product details component",
   "defaultLocale": "pt-BR",

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -218,9 +218,9 @@ class ProductDetails extends Component {
                   <div className="vtex-product-details__description-container pv2 w-100 h-100">
                     <ProductDescription
                       specifications={product.properties}
-                      skuName={selectedItem.name}>
-                      <span className="measure-wide">{product.description}</span>
-                    </ProductDescription>
+                      skuName={selectedItem.name}
+                      description={product.description}
+                    />
                   </div>
                 </div>
               )


### PR DESCRIPTION
#### What is the purpose of this pull request?
Pass the description as a prop instead of children. Related PR vtex-apps/store-components#106.

#### What problem is this solving?
The `ProductDescription` component needs the actual string of the description to unescape the HTML it contains to enable rich descriptions.

#### How should this be manually tested?
[Access this workspace](https://htmlescape--storecomponents.myvtex.com/samsung-s9/p).

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
