### PR TITLE
WIP

### DIFF
--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -110,7 +110,7 @@ class ProductDetails extends Component {
   }
 
   render() {
-    const { productQuery: { product }, displayVertically } = this.props
+    const { productQuery: { product, loading }, displayVertically } = this.props
 
     const shouldDisplayLoader = !product
 
@@ -215,7 +215,10 @@ class ProductDetails extends Component {
                       </div>
                     ) : (
                       <div className="pv4">
-                        <AvailabilitySubscriber skuId={selectedItem.itemId} />
+                        <AvailabilitySubscriber 
+                          skuId={selectedItem.itemId} 
+                          loading={loading}
+                        />
                       </div>
                     )}
                     <div className="flex w-100 pv2">
@@ -244,6 +247,7 @@ class ProductDetails extends Component {
                     specifications={product.properties}
                     skuName={selectedItem.name}
                     description={product.description}
+                    loading={loading}
                   />
                 </div>
               </div>


### PR DESCRIPTION
#### What is the purpose of this pull request?
We now have the possibility to reuse data from cache and we should use this ability to make a preview for the product details page.

Since the data available in cache isn't complete, each component (ProductPrice, AvailabilitySubscription, etc) should know how to render its own ContentLoader while loading and while having partial data. 

The logic of each component should be 
- do I have enough data to render my UI ? 
- if yes, render normally,
- if not, render available data and make use of react-content-loader 

This PR should remove the monolithic loading preview from the whole page and make each component preview's itself

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
