### PR TITLE
Add divided Content Loader logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `ProductName`, `ProductPrice` and `ProductImages` loaders CSS.
 
 ## [0.5.2] - 2018-07-25
 ### Fixed

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -65,6 +65,12 @@ class ProductDetails extends Component {
     return (
       <div className="w-100" style={{ maxWidth: '600px' }}>
         <ContentLoader uniquekey={uniquekey} height={600} width={500}>
+          <rect x="13" y="46.23" rx="4" ry="4" width="164.97" height="14.72" />
+          <rect x="13" y="12" rx="3" ry="3" width="418.2" height="26.18" />
+          <rect x="13" y="69.88" rx="3" ry="3" width="115.5" height="8.96" />
+          <rect x="16" y="108.23" rx="3" ry="3" width="45.6" height="17.28" />
+          <rect x="73" y="95" rx="3" ry="3" width="233.16" height="34.82" />
+          <rect x="13" y="147.23" rx="0" ry="0" width="208" height="10.98" />
           <rect x="13" y="171.23" rx="0" ry="0" width="176" height="13.11" />
           <rect x="16.45" y="220.23" rx="0" ry="0" width="40" height="40" />
           <rect x="63.85" y="220.23" rx="0" ry="0" width="40" height="40" />
@@ -90,11 +96,6 @@ class ProductDetails extends Component {
 
   state = {
     skuIndex: null,
-    // Test Code
-    name: null,
-    skuName: null,
-    sellingPrice: null,
-    listPrice: null,
   }
 
   handleSkuChange = skuIndex => {
@@ -144,110 +145,84 @@ class ProductDetails extends Component {
 
   render() {
     const {
-      productQuery: { product, loading },
+      productQuery: { product },
       displayVertically,
     } = this.props
 
-    const shouldDisplayLoader = !product || loading
-
-    let selectedItem, commertialOffer, sellerId, skuItems, initialItemIndex
-
-    if (!shouldDisplayLoader) {
-      const [{ itemId: initialItem }] = product.items
-
-      skuItems = product.items.slice()
-      skuItems.sort(this.compareSku)
-
-      initialItemIndex = skuItems.findIndex(item => item.itemId === initialItem)
-
-      selectedItem = skuItems[this.state.skuIndex]
-      if (selectedItem == null) {
-        selectedItem = skuItems[initialItemIndex]
-      }
-
-      [{ commertialOffer }] = selectedItem.sellers
-      sellerId = parseInt(selectedItem.sellers[0].sellerId)
+    if (!product) {
+      return this.renderLoader()
     }
 
-    // Test code
-    if (!this.state.name) {
-      setTimeout(
-        () =>
-          this.setState({
-            name: product.productName,
-            skuName: selectedItem.name,
-          }),
-        2000
-      )
+    const [{ itemId: initialItem }] = product.items
 
-      setTimeout(
-        () =>
-          this.setState({
-            listPrice: commertialOffer.ListPrice,
-            sellingPrice: commertialOffer.Price,
-          }),
-        3000
-      )
-    }
+    const skuItems = product.items.slice()
+    skuItems.sort(this.compareSku)
+
+    const initialItemIndex = skuItems.findIndex(
+      item => item.itemId === initialItem
+    )
+
+    const selectedItem =
+      skuItems[this.state.skuIndex] || skuItems[initialItemIndex]
+    const [{ commertialOffer }] = selectedItem.sellers
+    const sellerId = parseInt(selectedItem.sellers[0].sellerId)
 
     return (
       <IntlInjector>
         {intl => (
           <NoSSR onSSR={this.renderLoader()}>
-            {shouldDisplayLoader ? (
-              this.renderLoader()
-            ) : (
-              <div className="vtex-product-details flex flex-wrap pa6">
-                <div className="vtex-product-details__images-container w-50-ns w-100-s pr5-ns">
-                  <div className="fr-ns w-100 h-100">
-                    <div className="flex justify-center">
-                      <ProductImages
-                        images={selectedItem.images}
-                        thumbnailSliderOrientation={
-                          displayVertically ? 'VERTICAL' : 'HORIZONTAL'
-                        }
-                      />
-                    </div>
+            <div className="vtex-product-details flex flex-wrap pa6">
+              <div className="vtex-product-details__images-container w-50-ns w-100-s pr5-ns">
+                <div className="fr-ns w-100 h-100">
+                  <div className="flex justify-center pt2">
+                    <ProductImages
+                      images={selectedItem.images}
+                      thumbnailSliderOrientation={
+                        displayVertically ? 'VERTICAL' : 'HORIZONTAL'
+                      }
+                    />
                   </div>
                 </div>
-                <div className="vtex-product-details__details-container w-50-ns w-100-s pl5-ns">
-                  <div className="fl-ns w-100">
-                    <div className="vtex-product-details__name-container pv2">
-                      {/* Test code */}
-                      <ProductName
-                        name={this.state.name}
-                        skuName={this.state.skuName}
-                        brandName={product.brand}
-                        productReference={product.productReference}
-                      />
-                    </div>
-                    {commertialOffer.AvailableQuantity > 0 && (
+              </div>
+              <div className="vtex-product-details__details-container w-50-ns w-100-s pl5-ns">
+                <div className="fl-ns w-100">
+                  <div className="vtex-product-details__name-container pv2">
+                    <ProductName
+                      name={product.productName}
+                      skuName={selectedItem.name}
+                      brandName={product.brand}
+                      productReference={product.productReference}
+                    />
+                  </div>
+                  {!Number.isNaN(+commertialOffer.AvailableQuantity) &&
+                    commertialOffer.AvailableQuantity > 0 && (
                       <div className="vtex-product-details__price-container pt1">
                         <ProductPrice
-                          listPrice={this.state.listPrice}
-                          sellingPrice={this.state.sellingPrice}
+                          listPrice={commertialOffer.ListPrice}
+                          sellingPrice={commertialOffer.Price}
                           installments={commertialOffer.Installments}
                           {...this.props.price}
                         />
                       </div>
                     )}
-                    <div className="pv2">
-                      <hr className="o-30" size="1" />
+                  <div className="pv2">
+                    <hr className="o-30" size="1" />
+                  </div>
+                  <div>
+                    <div className="f7">
+                      <FormattedMessage id="sku-label" />
                     </div>
-                    <div>
-                      <div className="f7">
-                        <FormattedMessage id="sku-label" />
-                      </div>
-                      <SKUSelector
-                        skuItems={skuItems}
-                        defaultIndex={initialItemIndex}
-                        onSKUSelected={this.handleSkuChange}
-                      />
-                    </div>
-                    <div className="pv2">
-                      <hr className="o-30" size="1" />
-                    </div>
-                    {commertialOffer.AvailableQuantity > 0 ? (
+                    <SKUSelector
+                      skuItems={skuItems}
+                      defaultIndex={initialItemIndex}
+                      onSKUSelected={this.handleSkuChange}
+                    />
+                  </div>
+                  <div className="pv2">
+                    <hr className="o-30" size="1" />
+                  </div>
+                  {!Number.isNaN(+commertialOffer.AvailableQuantity) &&
+                    (commertialOffer.AvailableQuantity > 0 ? (
                       <div>
                         <div className="pv2">
                           <BuyButton
@@ -274,37 +249,36 @@ class ProductDetails extends Component {
                       <div className="pv4">
                         <AvailabilitySubscriber skuId={selectedItem.itemId} />
                       </div>
-                    )}
-                    <div className="flex w-100 pv2">
-                      <div className="pv2 pr3 f6">
-                        <FormattedMessage id="share.label" />:
-                      </div>
-                      <Share
-                        {...this.props.share}
-                        title={intl.formatMessage(
-                          { id: 'share.title' },
-                          {
-                            product: product.productName,
-                            sku: selectedItem.name,
-                            store: account,
-                          }
-                        )}
-                      />
+                    ))}
+                  <div className="flex w-100 pv2">
+                    <div className="pv2 pr3 f6">
+                      <FormattedMessage id="share.label" />:
                     </div>
+                    <Share
+                      {...this.props.share}
+                      title={intl.formatMessage(
+                        { id: 'share.title' },
+                        {
+                          product: product.productName,
+                          sku: selectedItem.name,
+                          store: account,
+                        }
+                      )}
+                    />
                   </div>
                 </div>
-                <div className="pv4 w-100">
-                  <hr className="b--black-10" size="0" />
-                </div>
-                <div className="vtex-product-details__description-container pv2 w-100 h-100">
-                  <ProductDescription
-                    specifications={product.properties}
-                    skuName={selectedItem.name}
-                    description={product.description}
-                  />
-                </div>
               </div>
-            )}
+              <div className="pv4 w-100">
+                <hr className="b--black-10" size="0" />
+              </div>
+              <div className="vtex-product-details__description-container pv2 w-100 h-100">
+                <ProductDescription
+                  specifications={product.properties}
+                  skuName={selectedItem.name}
+                  description={product.description}
+                />
+              </div>
+            </div>
           </NoSSR>
         )}
       </IntlInjector>

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -2,9 +2,7 @@ import './global.css'
 
 import { mapObjIndexed, mergeDeepRight, path } from 'ramda'
 import React, { Component } from 'react'
-import ContentLoader from 'react-content-loader'
 import { FormattedMessage } from 'react-intl'
-import { NoSSR } from 'render'
 import {
   AvailabilitySubscriber,
   BuyButton,
@@ -59,41 +57,6 @@ class ProductDetails extends Component {
     }
   }
 
-  static Loader = () => {
-    const uniquekey = 'vtex-product-details-loader'
-
-    return (
-      <div className="w-100" style={{ maxWidth: '600px' }}>
-        <ContentLoader uniquekey={uniquekey} height={600} width={500}>
-          <rect x="13" y="46.23" rx="4" ry="4" width="164.97" height="14.72" />
-          <rect x="13" y="12" rx="3" ry="3" width="418.2" height="26.18" />
-          <rect x="13" y="69.88" rx="3" ry="3" width="115.5" height="8.96" />
-          <rect x="16" y="108.23" rx="3" ry="3" width="45.6" height="17.28" />
-          <rect x="73" y="95" rx="3" ry="3" width="233.16" height="34.82" />
-          <rect x="13" y="147.23" rx="0" ry="0" width="208" height="10.98" />
-          <rect x="13" y="171.23" rx="0" ry="0" width="176" height="13.11" />
-          <rect x="16.45" y="220.23" rx="0" ry="0" width="40" height="40" />
-          <rect x="63.85" y="220.23" rx="0" ry="0" width="40" height="40" />
-          <rect x="13" y="195.23" rx="0" ry="0" width="57" height="12" />
-          <rect x="13" y="279.63" rx="0" ry="0" width="105.02" height="32.8" />
-          <rect
-            x="132.85"
-            y="333.63"
-            rx="0"
-            ry="0"
-            width="174.72"
-            height="30.07"
-          />
-          <rect x="13" y="341.63" rx="0" ry="0" width="101.26" height="19" />
-          <rect x="13" y="395.63" rx="0" ry="0" width="115.2" height="15.96" />
-          <circle cx="161.91" cy="402" r="18" />
-          <circle cx="207.25" cy="402" r="18" />
-          <circle cx="253.38" cy="402" r="18" />
-        </ContentLoader>
-      </div>
-    )
-  }
-
   state = {
     skuIndex: null,
   }
@@ -120,27 +83,6 @@ class ProductDetails extends Component {
     return quantity === 0
       ? 1
       : (otherQuantity === 0 && -1) || price - otherPrice
-  }
-
-  renderLoader() {
-    const { displayVertically } = this.props
-
-    return (
-      <div className="vtex-product-details flex flex-wrap pa6">
-        <div className="vtex-product-details__images-container w-50-ns w-100-s pr5-ns">
-          <div className="fr-ns w-100 h-100">
-            <div className="flex justify-center">
-              <ProductImages.Loader isVertical={displayVertically} />
-            </div>
-          </div>
-        </div>
-        <div className="vtex-product-details__details-container w-50-ns w-100-s pl5-ns">
-          <div className="fl-ns w-100">
-            <ProductDetails.Loader />
-          </div>
-        </div>
-      </div>
-    )
   }
 
   get skuItems() {
@@ -189,127 +131,125 @@ class ProductDetails extends Component {
     return (
       <IntlInjector>
         {intl => (
-          <NoSSR onSSR={this.renderLoader()}>
-            <div className="vtex-product-details flex flex-wrap pa6">
-              <div className="vtex-product-details__images-container w-50-ns w-100-s pr5-ns">
-                <div className="fr-ns w-100 h-100">
-                  <div className="flex justify-center pt2">
-                    <ProductImages
-                      images={path(['images'], this.selectedItem)}
-                      thumbnailSliderOrientation={
-                        displayVertically ? 'VERTICAL' : 'HORIZONTAL'
-                      }
-                    />
-                  </div>
+          <div className="vtex-product-details flex flex-wrap pa6">
+            <div className="vtex-product-details__images-container w-50-ns w-100-s pr5-ns">
+              <div className="fr-ns w-100 h-100">
+                <div className="flex justify-center pt2">
+                  <ProductImages
+                    images={path(['images'], this.selectedItem)}
+                    thumbnailSliderOrientation={
+                      displayVertically ? 'VERTICAL' : 'HORIZONTAL'
+                    }
+                  />
                 </div>
-              </div>
-              <div className="vtex-product-details__details-container w-50-ns w-100-s pl5-ns">
-                <div className="fl-ns w-100">
-                  <div className="vtex-product-details__name-container pv2">
-                    <ProductName
-                      name={path(['productName'], product)}
-                      skuName={path(['name'], this.selectedItem)}
-                      brandName={path(['brand'], product)}
-                      productReference={path(['productReference'], product)}
-                    />
-                  </div>
-                  {(Number.isNaN(
-                    +path(['AvailableQuantity'], this.commertialOffer)
-                  ) ||
-                    path(['AvailableQuantity'], this.commertialOffer) > 0) && (
-                    <div className="vtex-product-details__price-container pt1">
-                      <ProductPrice
-                        listPrice={path(['ListPrice'], this.commertialOffer)}
-                        sellingPrice={path(['Price'], this.commertialOffer)}
-                        installments={path(
-                          ['Installments'],
-                          this.commertialOffer
-                        )}
-                        {...this.props.price}
-                      />
-                    </div>
-                  )}
-                  <div className="pv2">
-                    <hr className="o-30" size="1" />
-                  </div>
-                  <div>
-                    <div className="f7">
-                      <FormattedMessage id="sku-label" />
-                    </div>
-                    {product && (
-                      <SKUSelector
-                        skuItems={this.skuItems}
-                        defaultIndex={this.initialItemIndex}
-                        onSKUSelected={this.handleSkuChange}
-                      />
-                    )}
-                  </div>
-                  <div className="pv2">
-                    <hr className="o-30" size="1" />
-                  </div>
-                  {!Number.isNaN(
-                    +path(['AvailableQuantity'], this.commertialOffer)
-                  ) &&
-                    (path(['AvailableQuantity'], this.commertialOffer) > 0 ? (
-                      <div>
-                        <div className="pv2">
-                          <BuyButton
-                            skuItems={[
-                              {
-                                skuId: this.selectedItem.itemId,
-                                quantity: 1,
-                                seller: this.sellerId,
-                              },
-                            ]}>
-                            <FormattedMessage id="button-label" />
-                          </BuyButton>
-                        </div>
-                        <div className="pv4">
-                          {/* FIXME: Get this country data correctly */}
-                          <ShippingSimulator
-                            skuId={this.selectedItem.itemId}
-                            seller={this.sellerId}
-                            country="BRA"
-                          />
-                        </div>
-                      </div>
-                    ) : (
-                      <div className="pv4">
-                        <AvailabilitySubscriber
-                          skuId={this.selectedItem.itemId}
-                        />
-                      </div>
-                    ))}
-                  <div className="flex w-100 pv2">
-                    <div className="pv2 pr3 f6">
-                      <FormattedMessage id="share.label" />:
-                    </div>
-                    <Share
-                      {...this.props.share}
-                      title={intl.formatMessage(
-                        { id: 'share.title' },
-                        {
-                          product: path(['productName'], product),
-                          sku: path(['name'], this.selectedItem),
-                          store: account,
-                        }
-                      )}
-                    />
-                  </div>
-                </div>
-              </div>
-              <div className="pv4 w-100">
-                <hr className="b--black-10" size="0" />
-              </div>
-              <div className="vtex-product-details__description-container pv2 w-100 h-100">
-                <ProductDescription
-                  specifications={path(['properties'], product)}
-                  skuName={path(['name'], this.selectedItem)}
-                  description={path(['description'], product)}
-                />
               </div>
             </div>
-          </NoSSR>
+            <div className="vtex-product-details__details-container w-50-ns w-100-s pl5-ns">
+              <div className="fl-ns w-100">
+                <div className="vtex-product-details__name-container pv2">
+                  <ProductName
+                    name={path(['productName'], product)}
+                    skuName={path(['name'], this.selectedItem)}
+                    brandName={path(['brand'], product)}
+                    productReference={path(['productReference'], product)}
+                  />
+                </div>
+                {(Number.isNaN(
+                  +path(['AvailableQuantity'], this.commertialOffer)
+                ) ||
+                  path(['AvailableQuantity'], this.commertialOffer) > 0) && (
+                  <div className="vtex-product-details__price-container pt1">
+                    <ProductPrice
+                      listPrice={path(['ListPrice'], this.commertialOffer)}
+                      sellingPrice={path(['Price'], this.commertialOffer)}
+                      installments={path(
+                        ['Installments'],
+                        this.commertialOffer
+                      )}
+                      {...this.props.price}
+                    />
+                  </div>
+                )}
+                <div className="pv2">
+                  <hr className="o-30" size="1" />
+                </div>
+                <div>
+                  <div className="f7">
+                    <FormattedMessage id="sku-label" />
+                  </div>
+                  {product && (
+                    <SKUSelector
+                      skuItems={this.skuItems}
+                      defaultIndex={this.initialItemIndex}
+                      onSKUSelected={this.handleSkuChange}
+                    />
+                  )}
+                </div>
+                <div className="pv2">
+                  <hr className="o-30" size="1" />
+                </div>
+                {!Number.isNaN(
+                  +path(['AvailableQuantity'], this.commertialOffer)
+                ) &&
+                  (path(['AvailableQuantity'], this.commertialOffer) > 0 ? (
+                    <div>
+                      <div className="pv2">
+                        <BuyButton
+                          skuItems={[
+                            {
+                              skuId: this.selectedItem.itemId,
+                              quantity: 1,
+                              seller: this.sellerId,
+                            },
+                          ]}>
+                          <FormattedMessage id="button-label" />
+                        </BuyButton>
+                      </div>
+                      <div className="pv4">
+                        {/* FIXME: Get this country data correctly */}
+                        <ShippingSimulator
+                          skuId={this.selectedItem.itemId}
+                          seller={this.sellerId}
+                          country="BRA"
+                        />
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="pv4">
+                      <AvailabilitySubscriber
+                        skuId={this.selectedItem.itemId}
+                      />
+                    </div>
+                  ))}
+                <div className="flex w-100 pv2">
+                  <div className="pv2 pr3 f6">
+                    <FormattedMessage id="share.label" />:
+                  </div>
+                  <Share
+                    {...this.props.share}
+                    title={intl.formatMessage(
+                      { id: 'share.title' },
+                      {
+                        product: path(['productName'], product),
+                        sku: path(['name'], this.selectedItem),
+                        store: account,
+                      }
+                    )}
+                  />
+                </div>
+              </div>
+            </div>
+            <div className="pv4 w-100">
+              <hr className="b--black-10" size="0" />
+            </div>
+            <div className="vtex-product-details__description-container pv2 w-100 h-100">
+              <ProductDescription
+                specifications={path(['properties'], product)}
+                skuName={path(['name'], this.selectedItem)}
+                description={path(['description'], product)}
+              />
+            </div>
+          </div>
         )}
       </IntlInjector>
     )

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -65,10 +65,6 @@ class ProductDetails extends Component {
     return (
       <div className="w-100" style={{ maxWidth: '600px' }}>
         <ContentLoader uniquekey={uniquekey} height={600} width={500}>
-          <rect x="13" y="69.88" rx="3" ry="3" width="115.5" height="8.96" />
-          <rect x="16" y="108.23" rx="3" ry="3" width="45.6" height="17.28" />
-          <rect x="73" y="95" rx="3" ry="3" width="233.16" height="34.82" />
-          <rect x="13" y="147.23" rx="0" ry="0" width="208" height="10.98" />
           <rect x="13" y="171.23" rx="0" ry="0" width="176" height="13.11" />
           <rect x="16.45" y="220.23" rx="0" ry="0" width="40" height="40" />
           <rect x="63.85" y="220.23" rx="0" ry="0" width="40" height="40" />
@@ -97,6 +93,8 @@ class ProductDetails extends Component {
     // Test Code
     name: null,
     skuName: null,
+    sellingPrice: null,
+    listPrice: null,
   }
 
   handleSkuChange = skuIndex => {
@@ -181,6 +179,15 @@ class ProductDetails extends Component {
           }),
         2000
       )
+
+      setTimeout(
+        () =>
+          this.setState({
+            listPrice: commertialOffer.ListPrice,
+            sellingPrice: commertialOffer.Price,
+          }),
+        3000
+      )
     }
 
     return (
@@ -217,8 +224,8 @@ class ProductDetails extends Component {
                     {commertialOffer.AvailableQuantity > 0 && (
                       <div className="vtex-product-details__price-container pt1">
                         <ProductPrice
-                          listPrice={commertialOffer.ListPrice}
-                          sellingPrice={commertialOffer.Price}
+                          listPrice={this.state.listPrice}
+                          sellingPrice={this.state.sellingPrice}
                           installments={commertialOffer.Installments}
                           {...this.props.price}
                         />

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -65,8 +65,6 @@ class ProductDetails extends Component {
     return (
       <div className="w-100" style={{ maxWidth: '600px' }}>
         <ContentLoader uniquekey={uniquekey} height={600} width={500}>
-          <rect x="13" y="46.23" rx="4" ry="4" width="164.97" height="14.72" />
-          <rect x="13" y="12" rx="3" ry="3" width="418.2" height="26.18" />
           <rect x="13" y="69.88" rx="3" ry="3" width="115.5" height="8.96" />
           <rect x="16" y="108.23" rx="3" ry="3" width="45.6" height="17.28" />
           <rect x="73" y="95" rx="3" ry="3" width="233.16" height="34.82" />
@@ -96,6 +94,9 @@ class ProductDetails extends Component {
 
   state = {
     skuIndex: null,
+    // Test Code
+    name: null,
+    skuName: null,
   }
 
   handleSkuChange = skuIndex => {
@@ -170,6 +171,18 @@ class ProductDetails extends Component {
       sellerId = parseInt(selectedItem.sellers[0].sellerId)
     }
 
+    // Test code
+    if (!this.state.name) {
+      setTimeout(
+        () =>
+          this.setState({
+            name: product.productName,
+            skuName: selectedItem.name,
+          }),
+        2000
+      )
+    }
+
     return (
       <IntlInjector>
         {intl => (
@@ -193,9 +206,10 @@ class ProductDetails extends Component {
                 <div className="vtex-product-details__details-container w-50-ns w-100-s pl5-ns">
                   <div className="fl-ns w-100">
                     <div className="vtex-product-details__name-container pv2">
+                      {/* Test code */}
                       <ProductName
-                        name={product.productName}
-                        skuName={selectedItem.name}
+                        name={this.state.name}
+                        skuName={this.state.skuName}
                         brandName={product.brand}
                         productReference={product.productReference}
                       />

--- a/react/global.css
+++ b/react/global.css
@@ -17,6 +17,21 @@
     font-size: 1rem;
   }
 
+  .vtex-product-details .vtex-product-name__brand--loader {
+    rx: 3;
+    ry: 3;
+    width: 100%;
+    height: 26.1px;
+  }
+
+  .vtex-product-details .vtex-product-name__sku--loader {
+    rx: 4;
+    ry: 4;
+    y: 41.1px;
+    width: 164.97px;
+    height: 16.72px;
+  }
+
   .vtex-product-details .vtex-price-list__container {
     font-size: 0.75rem;
   }

--- a/react/global.css
+++ b/react/global.css
@@ -18,50 +18,50 @@
   }
 
   .vtex-product-details .vtex-product-name-loader {
-    padding-top: 10px;
-    max-height: 90px;
-    max-width: 450px;
+    padding-top: 0.625em;
+    max-height: 5.625em;
+    max-width: 28.125em;
   }
 
   .vtex-product-details .vtex-product-name__brand--loader {
     width: 100%;
-    height: 26.1px;
+    height: 1.631em;
   }
 
   .vtex-product-details .vtex-product-name__sku--loader {
-    y: 41.1px;
-    width: 164.97px;
-    height: 16.72px;
+    y: 2.569em;
+    width: 10.311em;
+    height: 1.045em;
   }
 
   .vtex-product-details .vtex-price-loader {
-    max-height: 170px;
+    max-height: 10.625em;
     max-width: 450px;
-    padding-top: 10px;
+    padding-top: 28.125em;
   }
 
   .vtex-product-details .vtex-price-list__container--loader {
-    width: 115.5px;
-    height: 8.96px;
+    width: 7.219em;
+    height: 0.56em;
   }
 
   .vtex-product-details .vtex-price-selling__label--loader {
-    width: 45.6px;
-    height: 17.28px;
+    width: 2.85em;
+    height: 1.08em;
     y: 38.35;
   }
 
   .vtex-product-details .vtex-price-selling--loader {
     x: 60;
     y: 25.12;
-    width: 233.16px;
-    height: 34.82px;
+    width: 14.572em;
+    height: 2.176em;
   }
 
   .vtex-product-details .vtex-price-savings--loader {
     y: 77.35;
-    width: 208px;
-    height: 10.98px;
+    width: 13em;
+    height: 0.686em;
   }
 
   .vtex-product-details .vtex-price-list__container {

--- a/react/global.css
+++ b/react/global.css
@@ -17,19 +17,51 @@
     font-size: 1rem;
   }
 
+  .vtex-product-details .vtex-product-name-loader {
+    padding-top: 10px;
+    max-height: 90px;
+    max-width: 450px;
+  }
+
   .vtex-product-details .vtex-product-name__brand--loader {
-    rx: 3;
-    ry: 3;
     width: 100%;
     height: 26.1px;
   }
 
   .vtex-product-details .vtex-product-name__sku--loader {
-    rx: 4;
-    ry: 4;
     y: 41.1px;
     width: 164.97px;
     height: 16.72px;
+  }
+
+  .vtex-product-details .vtex-price-loader {
+    max-height: 170px;
+    max-width: 450px;
+    padding-top: 10px;
+  }
+
+  .vtex-product-details .vtex-price-list__container--loader {
+    width: 115.5px;
+    height: 8.96px;
+  }
+
+  .vtex-product-details .vtex-price-selling__label--loader {
+    width: 45.6px;
+    height: 17.28px;
+    y: 38.35;
+  }
+
+  .vtex-product-details .vtex-price-selling--loader {
+    x: 60;
+    y: 25.12;
+    width: 233.16px;
+    height: 34.82px;
+  }
+
+  .vtex-product-details .vtex-price-savings--loader {
+    y: 77.35;
+    width: 208px;
+    height: 10.98px;
   }
 
   .vtex-product-details .vtex-price-list__container {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Remove the single content loader to show data that is already available.

#### What problem is this solving?

A single content loader is shown, but some product information is cached.

#### How should this be manually tested?

[Access the workspace](https://estacio--storecomponents.myvtex.com/motorola-moto-x4/p)

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/15948386/43282424-7f5e1ab4-90ec-11e8-94bb-738d0d466c1b.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
