### PR TITLE
Fix Content Loader on Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Content loader to work on Firefox.
 
 ## [0.6.2] - 2018-08-10
 ### Fixed

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -1,8 +1,8 @@
-import './global.css';
+import './global.css'
 
-import { mapObjIndexed, mergeDeepRight, path } from 'ramda';
-import React, { Component, Fragment } from 'react';
-import { FormattedMessage } from 'react-intl';
+import { mapObjIndexed, mergeDeepRight, path } from 'ramda'
+import React, { Component, Fragment } from 'react'
+import { FormattedMessage } from 'react-intl'
 import {
   AvailabilitySubscriber,
   BuyButton,
@@ -13,10 +13,10 @@ import {
   Share,
   ShippingSimulator,
   SKUSelector,
-} from 'vtex.store-components';
+} from 'vtex.store-components'
 
-import IntlInjector from './components/IntlInjector';
-import ProductDetailsPropTypes from './propTypes';
+import IntlInjector from './components/IntlInjector'
+import ProductDetailsPropTypes from './propTypes'
 
 const { account } = global.__RUNTIME__
 const productNameLoaderStyles = {

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -1,8 +1,8 @@
-import './global.css'
+import './global.css';
 
-import { mapObjIndexed, mergeDeepRight, path } from 'ramda'
-import React, { Component, Fragment } from 'react'
-import { FormattedMessage } from 'react-intl'
+import { mapObjIndexed, mergeDeepRight, path } from 'ramda';
+import React, { Component, Fragment } from 'react';
+import { FormattedMessage } from 'react-intl';
 import {
   AvailabilitySubscriber,
   BuyButton,
@@ -13,12 +13,56 @@ import {
   Share,
   ShippingSimulator,
   SKUSelector,
-} from 'vtex.store-components'
+} from 'vtex.store-components';
 
-import IntlInjector from './components/IntlInjector'
-import ProductDetailsPropTypes from './propTypes'
+import IntlInjector from './components/IntlInjector';
+import ProductDetailsPropTypes from './propTypes';
 
 const { account } = global.__RUNTIME__
+const productNameLoaderStyles = {
+  'vtex-product-name__brand--loader': {
+    x: 0,
+    width: '100%',
+    height: '1.631em',
+  },
+  'vtex-product-name__sku--loader': {
+    x: 0,
+    y: '2.569em',
+    width: '10.311em',
+    height: '1.045em',
+  },
+}
+const productPriceLoaderStyles = {
+  'vtex-price-list__container--loader': {
+    x: 0,
+    width: '7.219em',
+    height: '0.56em',
+  },
+  'vtex-price-selling__label--loader': {
+    x: 0,
+    y: '2em',
+    width: '2.85em',
+    height: '1.08em',
+  },
+  'vtex-price-selling--loader': {
+    x: '3.25em',
+    y: '0.86em',
+    width: '14.572em',
+    height: '2.176em',
+  },
+  'vtex-price-installments--loader': {
+    x: 0,
+    y: '3.75em',
+    width: '12em',
+    height: '0.825em',
+  },
+  'vtex-price-savings--loader': {
+    x: 0,
+    y: '5em',
+    width: '10em',
+    height: '0.686em',
+  },
+}
 
 class ProductDetails extends Component {
   static defaultProps = {
@@ -129,6 +173,7 @@ class ProductDetails extends Component {
               <div className="fl-ns w-100">
                 <div className="vtex-product-details__name-container pv2">
                   <ProductName
+                    styles={productNameLoaderStyles}
                     name={path(['productName'], product)}
                     skuName={path(['name'], this.selectedItem)}
                     brandName={path(['brand'], product)}
@@ -141,6 +186,7 @@ class ProductDetails extends Component {
                   path(['AvailableQuantity'], this.commertialOffer) > 0) && (
                   <div className="vtex-product-details__price-container pt1">
                     <ProductPrice
+                      styles={productPriceLoaderStyles}
                       listPrice={path(['ListPrice'], this.commertialOffer)}
                       sellingPrice={path(['Price'], this.commertialOffer)}
                       installments={path(

--- a/react/global.css
+++ b/react/global.css
@@ -23,45 +23,10 @@
     max-width: 28.125em;
   }
 
-  .vtex-product-details .vtex-product-name__brand--loader {
-    width: 100%;
-    height: 1.631em;
-  }
-
-  .vtex-product-details .vtex-product-name__sku--loader {
-    y: 2.569em;
-    width: 10.311em;
-    height: 1.045em;
-  }
-
   .vtex-product-details .vtex-price-loader {
-    max-height: 10.625em;
-    max-width: 450px;
-    padding-top: 28.125em;
-  }
-
-  .vtex-product-details .vtex-price-list__container--loader {
-    width: 7.219em;
-    height: 0.56em;
-  }
-
-  .vtex-product-details .vtex-price-selling__label--loader {
-    width: 2.85em;
-    height: 1.08em;
-    y: 38.35;
-  }
-
-  .vtex-product-details .vtex-price-selling--loader {
-    x: 60;
-    y: 25.12;
-    width: 14.572em;
-    height: 2.176em;
-  }
-
-  .vtex-product-details .vtex-price-savings--loader {
-    y: 77.35;
-    width: 13em;
-    height: 0.686em;
+    height: 7em;
+    max-width: 28.125em;
+    padding-top: 0.5em;
   }
 
   .vtex-product-details .vtex-price-list__container {


### PR DESCRIPTION
#### What is the purpose of this pull request?
On Firefox, it was not possible to determine the SVG's style via CSS/Style prop. So, what works on Chrome and Safari, doesn't work on Firefox. To work in all browsers, the found solution was pass every style via elements properties.

#### What problem is this solving?
Content Loaders not rendering on Firefox.

#### How should this be manually tested?

[Access the workspace](https://estacio--storecomponents.myvtex.com/)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/44031926-dfd3cd10-9edb-11e8-8168-2e0e0cf48f61.png)


#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
