### PR TITLE
Add default padding matching page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Default padding matching page.
 
 ## [0.7.0] - 2018-08-31
 ### Added

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -163,7 +163,7 @@ class ProductDetails extends Component {
     return (
       <IntlInjector>
         {intl => (
-          <div className="vtex-product-details flex flex-wrap pa6">
+          <div className="vtex-product-details vtex-page-padding flex flex-wrap pa6">
             <div className="vtex-product-details__images-container w-50-ns w-100-s pr5-ns">
               <div className="fr-ns w-100 h-100">
                 <div className="flex justify-center pt2">
@@ -236,8 +236,7 @@ class ProductDetails extends Component {
                               seller: this.sellerId,
                             },
                           ]
-                        }
-                      >
+                        }>
                         <FormattedMessage id="button-label" />
                       </BuyButton>
                     </div>


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add default padding matching page

#### What problem is this solving?

ProductDetails had no padding.

#### How should this be manually tested?
[Access the workspace](https://padding--storecomponents.myvtex.com/porsche-911/p) and change the page's size.

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/15948386/45313598-bb801f00-b505-11e8-9b3d-722ad017a5ec.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
