### PR TITLE
Center using vtex-page-padding class instead of tachyons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.8.3] - 2018-11-07
 ### Fixed
 - Center using vtex-page-padding class instead of tachyons.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Center using vtex-page-padding class instead of tachyons.
 
 ## [0.8.2] - 2018-11-07
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "product-details",
   "vendor": "vtex",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "title": "Product Details",
   "description": "Product details component",
   "defaultLocale": "pt-BR",

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -174,7 +174,7 @@ class ProductDetails extends Component {
     return (
       <IntlInjector>
         {intl => (
-          <div className="vtex-page-padding">
+          <div className="vtex-page-padding center">
             <ExtensionPoint
               id="breadcrumb"
               term={term}

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -182,7 +182,7 @@ class ProductDetails extends Component {
               categories={categories}
             />
 
-            <div className="vtex-product-details flex flex-wrap pb7">
+            <div className="vtex-product-details flex flex-wrap pl4 pr4">
               <div className="vtex-product-details__images-container w-50-ns w-100-s pr5-ns">
                 <div className="fr-ns w-100 h-100">
                   <div className="flex justify-center pt2">


### PR DESCRIPTION
#### What is the purpose of this pull request?
Addition of center tachyon along side vtex-page-padding.

#### What problem is this solving?
Due use of vtex-page-padding class, the center tachyon is required.

#### How should this be manually tested?
[Access this workspace](https://alignheader--storecomponents.myvtex.com/)

#### Screenshots or example usage
The product-details must be centralized and using vtex-page-padding as reference

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
