### PR TITLE
Fix/no description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove product description when there is no description and remove SkuSelector when there is no variations
 
 ## [0.8.1] - 2018-10-05
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.8.2] - 2018-11-07
 ### Fixed
 - Remove product description when there is no description and remove SkuSelector when there is no variations
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "product-details",
   "vendor": "vtex",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "title": "Product Details",
   "description": "Product details component",
   "defaultLocale": "pt-BR",

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -167,6 +167,10 @@ class ProductDetails extends Component {
       path(['AvailableQuantity'], this.commertialOffer) > 0
     const country = path(['culture', 'country'], runtime)
 
+    const specifications = path(['properties'], product)
+    const skuName = path(['name'], this.selectedItem)
+    const description = path(['description'], product)
+
     return (
       <IntlInjector>
         {intl => (
@@ -178,7 +182,7 @@ class ProductDetails extends Component {
               categories={categories}
             />
 
-            <div className="vtex-product-details flex flex-wrap">
+            <div className="vtex-product-details flex flex-wrap pb7">
               <div className="vtex-product-details__images-container w-50-ns w-100-s pr5-ns">
                 <div className="fr-ns w-100 h-100">
                   <div className="flex justify-center pt2">
@@ -284,16 +288,20 @@ class ProductDetails extends Component {
                   </div>
                 </div>
               </div>
-              <div className="pv4 w-100">
-                <hr className="b--black-10" size="0" />
-              </div>
-              <div className="vtex-product-details__description-container pv2 w-100 h-100">
-                <ProductDescription
-                  specifications={path(['properties'], product)}
-                  skuName={path(['name'], this.selectedItem)}
-                  description={path(['description'], product)}
-                />
-              </div>
+              {description && specifications && (
+                <Fragment>
+                  <div className="pv4 w-100">
+                    <hr className="b--black-10" size="0" />
+                  </div>
+                  <div className="vtex-product-details__description-container pv2 w-100 h-100">
+                    <ProductDescription
+                      specifications={specifications}
+                      skuName={skuName}
+                      description={description}
+                    />
+                  </div>
+                </Fragment>
+              )}
             </div>
           </div>
         )}

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -171,6 +171,8 @@ class ProductDetails extends Component {
     const skuName = path(['name'], this.selectedItem)
     const description = path(['description'], product)
 
+    console.log('skuItems', this.skuItems)
+
     return (
       <IntlInjector>
         {intl => (
@@ -224,18 +226,20 @@ class ProductDetails extends Component {
                         />
                       </div>
                     )}
-                  <div className="pv2">
-                    <hr className="o-30" size="1" />
-                  </div>
-                  <div>
-                    {product && (
-                      <SKUSelector
-                        skuItems={this.skuItems}
-                        skuSelected={this.selectedItem}
-                        productSlug={product.linkText}
-                      />
+                  {product && this.selectedItem.variations
+                    && this.selectedItem.variations.length > 0
+                    && (
+                      <Fragment>
+                        <div className="pv2">
+                          <hr className="o-30" size="1" />
+                        </div>
+                        <SKUSelector
+                          skuItems={this.skuItems}
+                          skuSelected={this.selectedItem}
+                          productSlug={product.linkText}
+                        />
+                      </Fragment>
                     )}
-                  </div>
                   <div className="pv2">
                     <hr className="o-30" size="1" />
                   </div>

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -171,8 +171,6 @@ class ProductDetails extends Component {
     const skuName = path(['name'], this.selectedItem)
     const description = path(['description'], product)
 
-    console.log('skuItems', this.skuItems)
-
     return (
       <IntlInjector>
         {intl => (


### PR DESCRIPTION
#### What is the purpose of this pull request?

Don't show `ProductDescription.Loader` when there is no description for the product and remove a line separator when `SkuSelector` is not rendered


#### What problem is this solving?

Some product has no content to display `SkuSelector`, so the component is rendering two lines to separate the buy button and product information. The other problem is that when a product has no description, `ProductDescription` renders a loader anyway.

#### How should this be manually tested?
[Product with no SkuSelector](https://productdescriptionloader--storecomponents.myvtex.com/iphone-xs/p)
[Product with SkuSeletor](https://productdescriptionloader--storecomponents.myvtex.com/tenis-mizuno-wave-viper-3-masculino/p)

#### Screenshots or example usage
![captura de tela de 2018-11-07 03-30-41](https://user-images.githubusercontent.com/8517023/48131702-c0482180-e26f-11e8-86e0-fe955a97b6f5.png)

`SkuSelector`
![captura de tela de 2018-11-07 03-34-57](https://user-images.githubusercontent.com/8517023/48131891-62680980-e270-11e8-81b5-19608192c70d.png)
![captura de tela de 2018-11-07 03-35-12](https://user-images.githubusercontent.com/8517023/48131894-6562fa00-e270-11e8-845e-21d55012bdf8.png)


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
