### PR TITLE
Remove share label from locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Share label from `locales`.
 
 ## [1.0.0] - 2018-11-28
 ### Changed

--- a/react/locales/en-US.json
+++ b/react/locales/en-US.json
@@ -4,6 +4,5 @@
   "editor.product-details.maxImages.title": "Max thumbnail images",
   "editor.product-details.displayVertically.title": "Display thumbnails vertically",
   "button-label": "Buy",
-  "share.label": "SHARE",
   "share.title": "{product} {sku} at {store}: "
 }

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -4,6 +4,5 @@
   "editor.product-details.maxImages.title": "Número máximo de imágenes en miniatura",
   "editor.product-details.displayVertically.title": "Mostrar miniaturas verticalmente",
   "button-label": "Comprar",
-  "share.label": "COMPARTIR",
   "share.title": "{product} {sku} en la {store}: "
 }

--- a/react/locales/pt-BR.json
+++ b/react/locales/pt-BR.json
@@ -4,6 +4,5 @@
   "editor.product-details.maxImages.title": "Número máximo de imagens em miniatura",
   "editor.product-details.displayVertically.title": "Exibir miniaturas na vertical",
   "button-label": "Comprar",
-  "share.label": "COMPARTILHE",
   "share.title": "{product} {sku} na {store}: "
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Remove unused locale text

#### What problem is this solving?

This label isn't responsability of `product-details` anymore

#### How should this be manually tested?
[Workspace](https://sharelabel--storecomponents.myvtex.com/iphone-xs/p)
#### Screenshots or example usage
![captura de tela de 2018-11-29 14-58-56](https://user-images.githubusercontent.com/8517023/49241672-4d9e1200-f3e7-11e8-9126-5218bb144cb8.png)

#### Types of changes

* [X] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
