### PR TITLE
Replace image URL just for legacy file manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.3.2] - 2019-01-08
 ### Fix
 - Make a replace in the image URL just for legacy file manager.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fix
+- Make a replace in the image URL just for legacy file manager.
 
 ## [1.3.1] - 2019-01-04
 ### Fixed
@@ -13,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.3.0] - 2018-12-20
 ### Added
-- Support to messages builder. 
+- Support to messages builder.
 
 ## [1.2.0] - 2018-12-18
 ### Added
@@ -48,7 +50,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.0.1] - 2018-11-30
 ### Changed
-- Update store-components major version. 
+- Update store-components major version.
 
 ### Removed
 - Share label from `locales`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "product-details",
   "vendor": "vtex",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "title": "Product Details",
   "description": "Product details component",
   "defaultLocale": "pt-BR",

--- a/react/utils/generateUrl.js
+++ b/react/utils/generateUrl.js
@@ -4,19 +4,30 @@ export const MAX_WIDTH = 3000
 export const MAX_HEIGHT = 4000
 
 /**
- * Having the url below as base,
+ * Having the url below as base for the LEGACY file manager,
  * https://storecomponents.vteximg.com.br/arquivos/ids/155472/Frame-3.jpg?v=636793763985400000
  * the following regex will match https://storecomponents.vteximg.com.br/arquivos/ids/155472
  *
  * Also matches urls with defined sizes like:
  * https://storecomponents.vteximg.com.br/arquivos/ids/155473-160-auto
  * @type {RegExp}
+ *
+ * On the new vtex.file-manager isn't necessary replace the URL, just add the param on the querystring, like:
+ * "?width=WIDTH&height=HEIGHT&aspect=true"
+ *
  */
 const baseUrlRegex = new RegExp(/.+ids\/(\d+)/)
 
 export function cleanImageUrl(imageUrl) {
   const result = baseUrlRegex.exec(imageUrl)
   if (result.length > 0) return result[0]
+}
+
+function replaceLegacyFileManager(imageUrl, width, height) {
+  if (!imageUrl.includes('/arquivos/ids/')) return imageUrl
+  imageUrl = cleanImageUrl(imageUrl)
+  imageUrl = `${imageUrl}-${width}-${height}`
+  return imageUrl
 }
 
 export function changeImageUrlSize(
@@ -28,7 +39,8 @@ export function changeImageUrlSize(
   typeof width === 'number' && (width = Math.min(width, MAX_WIDTH))
   typeof height === 'number' && (height = Math.min(height, MAX_HEIGHT))
 
-  imageUrl = cleanImageUrl(imageUrl)
+  imageUrl = replaceLegacyFileManager(imageUrl, width, height)
+  imageUrl = `${imageUrl}${imageUrl.split('?')[1] ? '&' : '?'}width=${width}&height=${height}&aspect=true`
 
-  return `${imageUrl}-${width}-${height}`
+  return imageUrl
 }

--- a/react/utils/generateUrl.js
+++ b/react/utils/generateUrl.js
@@ -23,8 +23,10 @@ export function cleanImageUrl(imageUrl) {
   if (result.length > 0) return result[0]
 }
 
-function replaceLegacyFileManager(imageUrl, width, height) {
-  if (!imageUrl.includes('/arquivos/ids/')) return imageUrl
+function replaceLegacyFileManagerUrl(imageUrl, width, height) {
+  const legacyUrlPattern = '/arquivos/ids/'
+  const isLegacyUrl = imageUrl.includes(legacyUrlPattern)
+  if (!isLegacyUrl) return imageUrl
   imageUrl = cleanImageUrl(imageUrl)
   imageUrl = `${imageUrl}-${width}-${height}`
   return imageUrl
@@ -39,8 +41,9 @@ export function changeImageUrlSize(
   typeof width === 'number' && (width = Math.min(width, MAX_WIDTH))
   typeof height === 'number' && (height = Math.min(height, MAX_HEIGHT))
 
-  imageUrl = replaceLegacyFileManager(imageUrl, width, height)
-  imageUrl = `${imageUrl}${imageUrl.split('?')[1] ? '&' : '?'}width=${width}&height=${height}&aspect=true`
+  imageUrl = replaceLegacyFileManagerUrl(imageUrl, width, height)
+  const queryStringSeparator = imageUrl.includes('?') ? '&' : '?'
+  imageUrl = `${imageUrl}${queryStringSeparator}width=${width}&height=${height}&aspect=true`
 
   return imageUrl
 }

--- a/react/utils/generateUrl.js
+++ b/react/utils/generateUrl.js
@@ -27,9 +27,7 @@ function replaceLegacyFileManagerUrl(imageUrl, width, height) {
   const legacyUrlPattern = '/arquivos/ids/'
   const isLegacyUrl = imageUrl.includes(legacyUrlPattern)
   if (!isLegacyUrl) return imageUrl
-  imageUrl = cleanImageUrl(imageUrl)
-  imageUrl = `${imageUrl}-${width}-${height}`
-  return imageUrl
+  return `${cleanImageUrl(imageUrl)}-${width}-${height}`
 }
 
 export function changeImageUrlSize(
@@ -41,9 +39,8 @@ export function changeImageUrlSize(
   typeof width === 'number' && (width = Math.min(width, MAX_WIDTH))
   typeof height === 'number' && (height = Math.min(height, MAX_HEIGHT))
 
-  imageUrl = replaceLegacyFileManagerUrl(imageUrl, width, height)
-  const queryStringSeparator = imageUrl.includes('?') ? '&' : '?'
-  imageUrl = `${imageUrl}${queryStringSeparator}width=${width}&height=${height}&aspect=true`
+  const normalizedImageUrl = replaceLegacyFileManagerUrl(imageUrl, width, height)
+  const queryStringSeparator = normalizedImageUrl.includes('?') ? '&' : '?'
 
-  return imageUrl
+  return `${normalizedImageUrl}${queryStringSeparator}width=${width}&height=${height}&aspect=true`
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

The new **vtex.file-manager** uses querystring for image resize, so when you try to make the replace on the new system, you get an error.

We try to find the version of file-manager into the URL path, and replace when needed.
For all the others cases, the querystring is added to handle the new format and without breaking the old.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
