### PR TITLE
Pass ProductName Style through props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.4.3] - 2019-01-17
 ### Fixed
 - Pass `ProductName` style and tag through props.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Pass `ProductName` style through brandNameClass prop.
 
 ## [1.4.2] - 2019-01-11
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Pass `ProductName` style through brandNameClass prop.
+- Pass `ProductName` style and tag through props.
 
 ## [1.4.2] - 2019-01-11
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "product-details",
   "vendor": "vtex",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "title": "Product Details",
   "description": "Product details component",
   "defaultLocale": "pt-BR",

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -213,6 +213,7 @@ class ProductDetails extends Component {
       skuName: path(['name'], this.selectedItem),
       brandName: path(['brand'], product),
       productReference: path(['productReference'], product),
+      brandNameClass: 't-heading-4',
       ...this.props.name,
     }
 
@@ -252,7 +253,7 @@ class ProductDetails extends Component {
                   categories={categories}
                 />}
 
-                <div className={`${productDetails.nameContainer} c-on-base t-heading-4 mb4 dn-l`}>
+                <div className={`${productDetails.nameContainer} c-on-base mb4 dn-l`}>
                   <ProductName {...productNameProps} />
                 </div>
 
@@ -265,7 +266,7 @@ class ProductDetails extends Component {
                     </div>
                   </div>
                   <div className={`${productDetails.detailsContainer} pl8-l w-40-l w-100`}>
-                    <div className={`${productDetails.nameContainer} c-on-base dn db-l t-heading-4 mb4`}>
+                    <div className={`${productDetails.nameContainer} c-on-base dn db-l mb4`}>
                       <ProductName {...productNameProps} />
                     </div>
                     {showProductPrice && (

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -213,7 +213,7 @@ class ProductDetails extends Component {
       skuName: path(['name'], this.selectedItem),
       brandName: path(['brand'], product),
       productReference: path(['productReference'], product),
-      brandNameClass: 't-heading-4',
+      className: 't-heading-4',
       ...this.props.name,
     }
 

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -214,6 +214,7 @@ class ProductDetails extends Component {
       brandName: path(['brand'], product),
       productReference: path(['productReference'], product),
       className: 't-heading-4',
+      tag: 'h1',
       ...this.props.name,
     }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
As described in the title.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
To change the ProductName tag from a span tag to a h1 element, it is necessary to pass the style through props instead of wrapping them in divs.

#### How should this be manually tested?
[https://useheaderelement2--storecomponents.myvtex.com](https://useheaderelement2--storecomponents.myvtex.com)

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
