### PR TITLE
Adding blocks (or maybe interfaces if you look at it in another way)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Improve use of blocks and interfaces, enhacing reusability.
+- Improve use of blocks and interfaces, enhancing reusability.
 
 ## [1.7.0] - 2019-02-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.8.0] - 2019-02-05
 ### Added
 - Improve use of blocks and interfaces, enhancing reusability.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Improve use of blocks and interfaces, enhacing reusability.
 
 ## [1.7.0] - 2019-02-04
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "product-details",
   "vendor": "vtex",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "title": "Product Details",
   "description": "Product details component",
   "defaultLocale": "pt-BR",

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -4,9 +4,7 @@ import { mapObjIndexed, mergeDeepRight, path } from 'ramda'
 import { injectIntl, intlShape, FormattedMessage } from 'react-intl'
 
 import { ExtensionPoint, withRuntimeContext } from 'vtex.render-runtime'
-import {
-  Container,
-} from 'vtex.store-components'
+import { Container } from 'vtex.store-components'
 
 import { changeImageUrlSize } from './utils/generateUrl'
 import FixedButton from './components/FixedButton'
@@ -334,7 +332,10 @@ class ProductDetails extends Component {
                         productDetails.priceContainer
                       } pt1 mt mt7 mt4-l dn-l`}
                     >
-                      <ExtensionPoint id="product-price" {...productPriceProps} />
+                      <ExtensionPoint
+                        id="product-price"
+                        {...productPriceProps}
+                      />
                     </div>
                   )}
                   {showBuyButton ? (

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -5,15 +5,6 @@ import { injectIntl, intlShape, FormattedMessage } from 'react-intl'
 
 import { ExtensionPoint, withRuntimeContext } from 'vtex.render-runtime'
 import {
-  AvailabilitySubscriber,
-  BuyButton,
-  ProductDescription,
-  ProductImages,
-  ProductName,
-  ProductPrice,
-  Share,
-  ShippingSimulator,
-  SKUSelector,
   Container,
 } from 'vtex.store-components'
 
@@ -189,13 +180,16 @@ class ProductDetails extends Component {
   getImages() {
     const images = path(['images'], this.selectedItem)
 
-    return images ? images.map(
-      image => ({
-        imageUrls: imageSizes.map(size => changeImageUrlSize(image.imageUrl, size)),
-        thresholds,
-        thumbnailUrl: changeImageUrlSize(image.imageUrl, thumbnailSize),
-        imageText: image.imageText,
-      })) : []
+    return images
+      ? images.map(image => ({
+          imageUrls: imageSizes.map(size =>
+            changeImageUrlSize(image.imageUrl, size)
+          ),
+          thresholds,
+          thumbnailUrl: changeImageUrlSize(image.imageUrl, thumbnailSize),
+          imageText: image.imageText,
+        }))
+      : []
   }
 
   render() {
@@ -205,9 +199,7 @@ class ProductDetails extends Component {
       categories,
       runtime: {
         account,
-        culture: {
-          country,
-        },
+        culture: { country },
       },
       intl,
     } = this.props
@@ -222,8 +214,7 @@ class ProductDetails extends Component {
     const description = path(['description'], product)
 
     const buyButtonProps = {
-      skuItems:
-        this.selectedItem &&
+      skuItems: this.selectedItem &&
         this.sellerId && [
           {
             skuId: this.selectedItem.itemId,
@@ -271,10 +262,13 @@ class ProductDetails extends Component {
     }
 
     const availableQuantity = path(['AvailableQuantity'], this.commertialOffer)
-    const showProductPrice = (Number.isNaN(+availableQuantity) || availableQuantity > 0)
+    const showProductPrice =
+      Number.isNaN(+availableQuantity) || availableQuantity > 0
 
     return (
-      <Container className={`${productDetails.container} pt6 pb8 justify-center flex`}>
+      <Container
+        className={`${productDetails.container} pt6 pb8 justify-center flex`}
+      >
         <div className="w-100 mw9">
           <div className="mb7">
             {slug && categories && (
@@ -285,79 +279,108 @@ class ProductDetails extends Component {
               />
             )}
 
-            <div className={`${productDetails.nameContainer} c-on-base mb4 dn-l`}>
-              <ProductName {...productNameProps} />
+            <div
+              className={`${productDetails.nameContainer} c-on-base mb4 dn-l`}
+            >
+              <ExtensionPoint id="product-name" {...productNameProps} />
             </div>
-
             <div className="flex flex-wrap">
               <div className="w-60-l w-100">
                 <div className="fr-ns w-100 h-100">
                   <div className="flex justify-center">
-                    <ProductImages images={this.getImages()} />
+                    <ExtensionPoint
+                      id="product-images"
+                      images={this.getImages()}
+                    />
                   </div>
                 </div>
               </div>
-              <div className={`${productDetails.detailsContainer} pl8-l w-40-l w-100`}>
-                <div className={`${productDetails.nameContainer} c-on-base dn db-l mb4`}>
-                  <ProductName {...productNameProps} />
+              <div
+                className={`${
+                  productDetails.detailsContainer
+                } pl8-l w-40-l w-100`}
+              >
+                <div
+                  className={`${
+                    productDetails.nameContainer
+                  } c-on-base dn db-l mb4`}
+                >
+                  <ExtensionPoint id="product-name" {...productNameProps} />
                 </div>
                 {showProductPrice && (
-                  <div className={`${productDetails.priceContainer} pt1 dn db-l`}>
-                    <ProductPrice {...productPriceProps} />
+                  <div
+                    className={`${productDetails.priceContainer} pt1 dn db-l`}
+                  >
+                    <ExtensionPoint id="product-price" {...productPriceProps} />
                   </div>
                 )}
                 <div className="mv2 mt5 dn db-l">
                   <hr className="o-30" size="1" />
                 </div>
                 <div className="mt6">
-                  {product && this.selectedItem.variations && this.selectedItem.variations.length > 0 && (
-                    <SKUSelector
-                      skuItems={this.skuItems}
-                      skuSelected={this.selectedItem}
-                      productSlug={product.linkText}
-                    />
-                  )}
+                  {product &&
+                    this.selectedItem.variations &&
+                    this.selectedItem.variations.length > 0 && (
+                      <ExtensionPoint
+                        id="sku-selector"
+                        skuItems={this.skuItems}
+                        skuSelected={this.selectedItem}
+                        productSlug={product.linkText}
+                      />
+                    )}
                   {showProductPrice && (
-                    <div className={`${productDetails.priceContainer} pt1 mt mt7 mt4-l dn-l`}>
-                      <ProductPrice {...productPriceProps} />
+                    <div
+                      className={`${
+                        productDetails.priceContainer
+                      } pt1 mt mt7 mt4-l dn-l`}
+                    >
+                      <ExtensionPoint id="product-price" {...productPriceProps} />
                     </div>
                   )}
                   {showBuyButton ? (
                     <div className="pv2 dn db-l mt8">
-                      <BuyButton {...buyButtonProps}>
+                      <ExtensionPoint id="buy-button" {...buyButtonProps}>
                         <FormattedMessage id="addToCartButton.label" />
-                      </BuyButton>
+                      </ExtensionPoint>
                     </div>
                   ) : (
                     <div className="pv4">
-                      <AvailabilitySubscriber skuId={this.selectedItem.itemId} />
+                      <ExtensionPoint
+                        id="availability-subscriber"
+                        skuId={this.selectedItem.itemId}
+                      />
                     </div>
                   )}
                   <FixedButton>
                     <div className="dn-l bg-base w-100 ph5 pv3">
-                      <BuyButton {...buyButtonProps}>
+                      <ExtensionPoint id="buy-button" {...buyButtonProps}>
                         <FormattedMessage id="addToCartButton.label" />
-                      </BuyButton>
+                      </ExtensionPoint>
                     </div>
                   </FixedButton>
                   <div className="mt8">
-                    <ShippingSimulator
+                    <ExtensionPoint
+                      id="shipping-simulator"
                       skuId={path(['itemId'], this.selectedItem)}
                       seller={this.sellerId}
                       country={country}
                     />
                   </div>
                   <div className="flex w-100 mt7">
-                    <Share
+                    <ExtensionPoint
+                      id="share"
                       shareLabelClass="c-muted-2 t-small mb3"
                       className="db"
                       {...this.props.share}
                       loading={!path(['name'], this.selectedItem)}
-                      title={intl.formatMessage({ id: 'share.title' }, {
-                        product: path(['productName'], product),
-                        sku: path(['name'], this.selectedItem),
-                        store: account,
-                      })}
+                      title={intl.formatMessage(
+                        { id: 'share.title' },
+                        {
+                          product: path(['productName'], product),
+                          sku: path(['name'], this.selectedItem),
+                          store: account,
+                        }
+                      )}
                     />
                   </div>
                 </div>
@@ -370,7 +393,8 @@ class ProductDetails extends Component {
                 <hr className="o-30 db" size="1" />
               </div>
               <div className="pv2 w-100 mt8 h-100">
-                <ProductDescription
+                <ExtensionPoint
+                  id="product-description"
                   specifications={specifications}
                   skuName={skuName}
                   description={description}

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -1,6 +1,6 @@
 {
   "product-details": {
-    "required": [
+    "blocks": [
       "product-name",
       "product-images",
       "product-price",
@@ -8,12 +8,8 @@
       "buy-button",
       "sku-selector",
       "shipping-simulator",
-      "availability-subscriber"
-    ],
-    "allowed": [
-      "breadcrumb",
+      "availability-subscriber",
       "share"
-    ],
-    "component": "ProductDetails"
-  }
+    ]
+  } 
 }

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -1,6 +1,7 @@
 {
   "product-details": {
     "blocks": [
+      "breadcrumb",
       "product-name",
       "product-images",
       "product-price",


### PR DESCRIPTION
#### What is the purpose of this pull request?

It replaces the traditional imports of `store-components`' components with **brand new render8ish v2 2019** _Extension Points_ using the new blocks interface 😄 

~It makes the breadcrumb appear again~

*ORDER OF RELEASE*
1. [`store-components`](https://github.com/vtex-apps/store-components/pull/278)
2. [`product-details`](https://github.com/vtex-apps/product-details/pull/81)
3. [`dreamstore`](https://github.com/vtex-apps/dreamstore/pull/120)

#### What problem is this solving?

The problem that were not possible to inject other components in this app _(like a custom buy-button for the Instore, randomly saying...)_

#### How should this be manually tested?

Using [this](https://inga--storecomponents.myvtex.com/) workspace.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [X] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
