### PR TITLE
Update BuyButton items props to use the Minicart's optimistic strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add the optimistic minicart strategy props to the `BuyButton`.
 
 ## [1.9.0] - 2019-02-12
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.10.0] - 2019-02-13
 ### Added
 - Add the optimistic minicart strategy props to the `BuyButton`.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "product-details",
   "vendor": "vtex",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "title": "Product Details",
   "description": "Product details component",
   "defaultLocale": "pt-BR",

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -227,12 +227,9 @@ class ProductDetails extends Component {
           variant: this.selectedItem.name,
           brand: product.brand,
           index: 0,
-
-          /* Optimistic props */
           detailUrl: `/${product.linkText}/p`,
           imageUrl: path(['images', '0', 'imageUrl'], this.selectedItem),
           listPrice: path(['sellers', '0', 'commertialOffer', 'ListPrice'], this.selectedItem),
-          /* End Optimistic props */
         },
       ],
       large: true,

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -217,17 +217,24 @@ class ProductDetails extends Component {
 
     const buyButtonProps = {
       skuItems: this.selectedItem &&
-        this.sellerId && [
-          {
-            skuId: this.selectedItem.itemId,
-            quantity: selectedQuantity,
-            seller: this.sellerId,
-            name: this.selectedItem.nameComplete,
-            price: this.commertialOffer.Price,
-            variant: this.selectedItem.name,
-            brand: product.brand,
-          },
-        ],
+      this.sellerId && [
+        {
+          skuId: this.selectedItem.itemId,
+          quantity: selectedQuantity,
+          seller: this.sellerId,
+          name: this.selectedItem.nameComplete,
+          price: this.commertialOffer.Price,
+          variant: this.selectedItem.name,
+          brand: product.brand,
+          index: 0,
+
+          /* Optimistic props */
+          detailUrl: `/${product.linkText}/p`,
+          imageUrl: path(['images', '0', 'imageUrl'], this.selectedItem),
+          listPrice: path(['sellers', '0', 'commertialOffer', 'ListPrice'], this.selectedItem),
+          /* End Optimistic props */
+        },
+      ],
       large: true,
       available: showBuyButton,
     }

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,9 @@
 {
   "name": "product-details",
   "version": "0.1.0",
+  "scripts": {
+    "test": "echo TODO"
+  },
   "dependencies": {
     "prop-types": "^15.6.2",
     "ramda": "^0.26.1",


### PR DESCRIPTION
**Related to vtex-apps/minicart#93**

#### What is the purpose of this pull request?

Update the buy-button items props so the product-details can use the minicart's optimistic strategy.

#### What problem is this solving?

Outdated props.

#### How should this be manually tested?

[Access the workspace](https://offline--storecomponents.myvtex.com)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
