### PR TITLE
Add tabs view mode to Product specifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.9.0] - 2019-02-12
 ### Added
 - Allow the product specifications render in tabs mode.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow the product specifications render in tabs mode.
 
 ## [1.8.1] - 2019-02-07
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "product-details",
   "vendor": "vtex",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "title": "Product Details",
   "description": "Product details component",
   "defaultLocale": "pt-BR",

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -4,7 +4,7 @@ import { mapObjIndexed, mergeDeepRight, path } from 'ramda'
 import { injectIntl, intlShape, FormattedMessage } from 'react-intl'
 
 import { ExtensionPoint, withRuntimeContext } from 'vtex.render-runtime'
-import { Container } from 'vtex.store-components'
+import { Container, ProductSpecifications } from 'vtex.store-components'
 
 import { changeImageUrlSize } from './utils/generateUrl'
 import FixedButton from './components/FixedButton'
@@ -76,6 +76,7 @@ class ProductDetails extends Component {
       showSku: false,
     },
     displayVertically: false,
+    productSpecificationsTabsMode: false,
   }
 
   static propTypes = {
@@ -200,6 +201,7 @@ class ProductDetails extends Component {
         culture: { country },
       },
       intl,
+      productSpecificationsTabsMode
     } = this.props
     const { selectedQuantity } = this.state
 
@@ -393,13 +395,21 @@ class ProductDetails extends Component {
               <div className="mv4">
                 <hr className="o-30 db" size="1" />
               </div>
-              <div className="pv2 w-100 mt8 h-100">
-                <ExtensionPoint
-                  id="product-description"
-                  specifications={specifications}
-                  skuName={skuName}
-                  description={description}
-                />
+              <div className={`flex ${productSpecificationsTabsMode ? 'flex-wrap' : ''}`}>
+                <div className={`pv2 w-100 mt8 h-100 ${productSpecificationsTabsMode ? 'w-100' : 'w-60'}`}>
+                  <ExtensionPoint
+                    id="product-description"
+                    skuName={skuName}
+                    description={description}
+                  />
+                </div>
+                <div className={`pv2 mt8 h-100 ${productSpecificationsTabsMode ? 'w-100' : 'w-40'}`}>
+                  <ExtensionPoint
+                    id="product-specifications"
+                    tabs={productSpecificationsTabsMode} 
+                    specifications={specifications}
+                  />
+                </div>
               </div>
             </div>
           )}

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -76,7 +76,7 @@ class ProductDetails extends Component {
       showSku: false,
     },
     displayVertically: false,
-    showSpecificationsTab: true,
+    showSpecificationsTab: false,
   }
 
   static propTypes = {
@@ -105,6 +105,8 @@ class ProductDetails extends Component {
     }),
     /** Product slug */
     slug: PropTypes.string.isRequired,
+    /** Product specifications tab mode */
+    showSpecificationsTab: PropTypes.bool,
   }
 
   static getSchema = props => {
@@ -408,7 +410,7 @@ class ProductDetails extends Component {
                 <div className="pv2 mt8 h-100 w-100">
                   <ExtensionPoint
                     id="product-specifications"
-                    tabs={showSpecificationsTab}
+                    tabsMode={showSpecificationsTab}
                     specifications={specifications}
                   />
                 </div>

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -4,7 +4,7 @@ import { mapObjIndexed, mergeDeepRight, path } from 'ramda'
 import { injectIntl, intlShape, FormattedMessage } from 'react-intl'
 
 import { ExtensionPoint, withRuntimeContext } from 'vtex.render-runtime'
-import { Container, ProductSpecifications } from 'vtex.store-components'
+import { Container } from 'vtex.store-components'
 
 import { changeImageUrlSize } from './utils/generateUrl'
 import FixedButton from './components/FixedButton'
@@ -76,7 +76,7 @@ class ProductDetails extends Component {
       showSku: false,
     },
     displayVertically: false,
-    productSpecificationsTabsMode: false,
+    showSpecificationsTab: true,
   }
 
   static propTypes = {
@@ -181,13 +181,13 @@ class ProductDetails extends Component {
 
     return images
       ? images.map(image => ({
-          imageUrls: imageSizes.map(size =>
-            changeImageUrlSize(image.imageUrl, size)
-          ),
-          thresholds,
-          thumbnailUrl: changeImageUrlSize(image.imageUrl, thumbnailSize),
-          imageText: image.imageText,
-        }))
+        imageUrls: imageSizes.map(size =>
+          changeImageUrlSize(image.imageUrl, size)
+        ),
+        thresholds,
+        thumbnailUrl: changeImageUrlSize(image.imageUrl, thumbnailSize),
+        imageText: image.imageText,
+      }))
       : []
   }
 
@@ -201,7 +201,7 @@ class ProductDetails extends Component {
         culture: { country },
       },
       intl,
-      productSpecificationsTabsMode
+      showSpecificationsTab
     } = this.props
     const { selectedQuantity } = this.state
 
@@ -298,12 +298,12 @@ class ProductDetails extends Component {
               <div
                 className={`${
                   productDetails.detailsContainer
-                } pl8-l w-40-l w-100`}
+                  } pl8-l w-40-l w-100`}
               >
                 <div
                   className={`${
                     productDetails.nameContainer
-                  } c-on-base dn db-l mb4`}
+                    } c-on-base dn db-l mb4`}
                 >
                   <ExtensionPoint id="product-name" {...productNameProps} />
                 </div>
@@ -332,7 +332,7 @@ class ProductDetails extends Component {
                     <div
                       className={`${
                         productDetails.priceContainer
-                      } pt1 mt mt7 mt4-l dn-l`}
+                        } pt1 mt mt7 mt4-l dn-l`}
                     >
                       <ExtensionPoint
                         id="product-price"
@@ -347,13 +347,13 @@ class ProductDetails extends Component {
                       </ExtensionPoint>
                     </div>
                   ) : (
-                    <div className="pv4">
-                      <ExtensionPoint
-                        id="availability-subscriber"
-                        skuId={this.selectedItem.itemId}
-                      />
-                    </div>
-                  )}
+                      <div className="pv4">
+                        <ExtensionPoint
+                          id="availability-subscriber"
+                          skuId={this.selectedItem.itemId}
+                        />
+                      </div>
+                    )}
                   <FixedButton>
                     <div className="dn-l bg-base w-100 ph5 pv3">
                       <ExtensionPoint id="buy-button" {...buyButtonProps}>
@@ -390,29 +390,31 @@ class ProductDetails extends Component {
               </div>
             </div>
           </div>
-          {description && specifications && (
-            <div className="ph5 ph0-ns">
-              <div className="mv4">
-                <hr className="o-30 db" size="1" />
-              </div>
-              <div className={`flex ${productSpecificationsTabsMode ? 'flex-wrap' : ''}`}>
-                <div className={`pv2 w-100 mt8 h-100 ${productSpecificationsTabsMode ? 'w-100' : 'w-60'}`}>
+          <div className={`${productDetails.informationsContainer}ph5 ph0-ns`}>
+            <div className="mv4">
+              <hr className="o-30 db" size="1" />
+            </div>
+            <div className={`flex ${showSpecificationsTab ? 'flex-wrap' : 'justify-between'}`}>
+              {description &&
+                <div className="pv2 mt8 h-100 w-100">
                   <ExtensionPoint
                     id="product-description"
                     skuName={skuName}
                     description={description}
                   />
                 </div>
-                <div className={`pv2 mt8 h-100 ${productSpecificationsTabsMode ? 'w-100' : 'w-40'}`}>
+              }
+              {specifications &&
+                <div className="pv2 mt8 h-100 w-100">
                   <ExtensionPoint
                     id="product-specifications"
-                    tabs={productSpecificationsTabsMode} 
+                    tabs={showSpecificationsTab}
                     specifications={specifications}
                   />
                 </div>
-              </div>
+              }
             </div>
-          )}
+          </div>
         </div>
       </Container>
     )

--- a/react/productDetails.css
+++ b/react/productDetails.css
@@ -7,3 +7,4 @@
 .detailsContainer {}
 .priceContainer {}
 .fixedButton {}
+.informationsContainer{}

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -10,7 +10,8 @@
       "sku-selector",
       "shipping-simulator",
       "availability-subscriber",
-      "share"
+      "share",
+      "product-specifications"
     ]
   } 
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -6,7 +6,8 @@
       "product-price",
       "sku-selector",
       "buy-button",
-      "product-description"
+      "product-description",
+      "product-specifications"
     ],
     "allowed": [
       "breadcrumb",


### PR DESCRIPTION
#### What is the purpose of this pull request?
Manage the CSS handle for productSpecifications when it is tabs/table. See also [here](https://github.com/vtex-apps/store-components/pull/288).
<!--- Describe your changes in detail. -->

#### What problem is this solving?
It is adjusting the _divs_ aligning side to side when the productSpecifications is in table view and putting the productSpecifications under the productDescription when it is in tabs view.
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
In this [Workspace](https://bruno--storecomponents.myvtex.com/shirt/p).

#### Screenshots or example usage
There are [here](https://github.com/vtex-apps/store-components/pull/288).

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
