### PR TITLE
Fix reading from undefined schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Trying to read schemas from `undefined` variables.
 
 ## [1.10.2] - 2019-02-19
 ### Fixed
@@ -72,7 +74,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Lateral padding.
 
-  
+
 ## [1.3.0] - 2018-12-20
 ### Added
 - Support to messages builder.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.10.4] - 2019-02-21
+
 ## [1.10.3] - 2019-02-21
 ### Fixed
 - Trying to read schemas from `undefined` variables.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.10.3] - 2019-02-21
 ### Fixed
 - Trying to read schemas from `undefined` variables.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "product-details",
   "vendor": "vtex",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "title": "Product Details",
   "description": "Product details component",
   "defaultLocale": "pt-BR",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "product-details",
   "vendor": "vtex",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "title": "Product Details",
   "description": "Product details component",
   "defaultLocale": "pt-BR",

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -109,30 +109,18 @@ class ProductDetails extends Component {
     showSpecificationsTab: PropTypes.bool,
   }
 
-  static getSchema = props => {
-    const shareSchema = Share.schema || Share.getSchema(props)
-    const priceSchema = mergeSchemaAndDefaultProps(
-      ProductPrice.schema || ProductPrice.getSchema(props),
-      'price'
-    )
-    const nameSchema = ProductName.schema || ProductName.getSchema(props)
-
-    return {
-      title: 'editor.product-details.title',
-      description: 'editor.product-details.description',
-      type: 'object',
-      properties: {
-        displayVertically: {
-          title: 'editor.product-details.displayVertically.title',
-          type: 'boolean',
-          default: false,
-          isLayout: true,
-        },
-        share: shareSchema,
-        price: priceSchema,
-        name: nameSchema,
-      },
-    }
+  static schema =  {
+    title: 'editor.product-details.title',
+    description: 'editor.product-details.description',
+    type: 'object',
+    properties: {
+      displayVertically: {
+        title: 'editor.product-details.displayVertically.title',
+        type: 'boolean',
+        default: false,
+        isLayout: true,
+      }
+    },
   }
 
   state = { selectedQuantity: 1 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change `getSchema` into a plain object as it doesn't need to get its children schemas.

#### What problem is this solving?
Breaks site editor.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
