### PR TITLE
Add thumb position on storefront

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Thumbnails position on storefront. 
 
 ## [1.11.2] - 2019-04-02
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.12.0] - 2019-04-08
 ### Added
 - Thumbnails position on storefront. 
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "product-details",
   "vendor": "vtex",
-  "version": "1.11.2",
+  "version": "1.12.0",
   "title": "Product Details",
   "description": "Product details component",
   "defaultLocale": "pt-BR",

--- a/messages/context.json
+++ b/messages/context.json
@@ -14,5 +14,8 @@
   "editor.product-details.displayVertically.title": "editor.product-details.displayVertically.title",
   "button-label": "button-label",
   "addToCartButton.label": "addToCartButton.label",
-  "share.title": "share.title"
+  "share.title": "share.title",
+  "editor.product-details.thumbnailsPosition.title": "editor.product-details.thumbnailsPosition.title",
+  "editor.product-details.thumbnailsPosition.left": "editor.product-details.thumbnailsPosition.left",
+  "editor.product-details.thumbnailsPosition.right": "editor.product-details.thumbnailsPosition.right"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -13,5 +13,8 @@
   "editor.product-details.showHighlight.title": "Show highlights",
   "editor.product-details.highlights.allSpecifications": "All Specifications",
   "editor.product-details.highlights.chooseDefault": "Groups Specification",
-  "editor.product-details.highlights.chooseDefaultSpecification": "Fields Specifications"
+  "editor.product-details.highlights.chooseDefaultSpecification": "Fields Specifications",
+  "editor.product-details.thumbnailsPosition.title": "Thumbnails position",
+  "editor.product-details.thumbnailsPosition.left": "Left",
+  "editor.product-details.thumbnailsPosition.right": "Right"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -13,5 +13,8 @@
   "editor.product-details.showHighlight.title": "Mostrar lo más destacados",
   "editor.product-details.highlights.allSpecifications": "Todas las especificaciones",
   "editor.product-details.highlights.chooseDefault": "Grupo del especificaciones personalizadas",
-  "editor.product-details.highlights.chooseDefaultSpecification": "Especificaciones personalizadas"
+  "editor.product-details.highlights.chooseDefaultSpecification": "Especificaciones personalizadas",
+  "editor.product-details.thumbnailsPosition.title": "Posición de miniaturas",
+  "editor.product-details.thumbnailsPosition.left": "Izquierda",
+  "editor.product-details.thumbnailsPosition.right": "Derecha"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -13,5 +13,8 @@
   "editor.product-details.showHighlight.title": "Mostrar destaques",
   "editor.product-details.highlights.allSpecifications": "Todas as especificações",
   "editor.product-details.highlights.chooseDefault": "Grupo de especificações personalizadas",
-  "editor.product-details.highlights.chooseDefaultSpecification": "Especificações personalizadas"
+  "editor.product-details.highlights.chooseDefaultSpecification": "Especificações personalizadas",
+  "editor.product-details.thumbnailsPosition.title": "Posição das miniaturas",
+  "editor.product-details.thumbnailsPosition.left": "Esquerda",
+  "editor.product-details.thumbnailsPosition.right": "Direita"
 }

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -22,6 +22,10 @@ import { Container } from 'vtex.store-components'
 import { changeImageUrlSize } from './utils/generateUrl'
 import FixedButton from './components/FixedButton'
 import { productShape } from './propTypes'
+import thumbnailsPosition, {
+  getThumbnailsPositionNames,
+  getThumbnailsPositionValues,
+} from './utils/thumbnailPositionEnum'
 
 import productDetails from './productDetails.css'
 
@@ -173,13 +177,13 @@ class ProductDetails extends Component {
 
     return images
       ? images.map(image => ({
-        imageUrls: imageSizes.map(size =>
-          changeImageUrlSize(image.imageUrl, size)
-        ),
-        thresholds,
-        thumbnailUrl: changeImageUrlSize(image.imageUrl, thumbnailSize),
-        imageText: image.imageText,
-      }))
+          imageUrls: imageSizes.map(size =>
+            changeImageUrlSize(image.imageUrl, size)
+          ),
+          thresholds,
+          thumbnailUrl: changeImageUrlSize(image.imageUrl, thumbnailSize),
+          imageText: image.imageText,
+        }))
       : []
   }
 
@@ -218,7 +222,11 @@ class ProductDetails extends Component {
         const highlightSpecificationGroup = specificationGroups.filter(
           x => x.name.toLowerCase() === item.trim().toLowerCase()
         )[0]
-        const highlight = propOr([], 'specifications', highlightSpecificationGroup)
+        const highlight = propOr(
+          [],
+          'specifications',
+          highlightSpecificationGroup
+        )
         return acc.concat(highlight)
       }, [])
       return highlights
@@ -228,7 +236,9 @@ class ProductDetails extends Component {
       const specificationNames = typeSpecifications.trim().split(',')
       const allSpecifications = propOr([], 'properties', product)
       const highlights = specificationNames.reduce((acc, item) => {
-        const highlight = allSpecifications.filter(x => x.name.toLowerCase() === item.trim().toLowerCase())
+        const highlight = allSpecifications.filter(
+          x => x.name.toLowerCase() === item.trim().toLowerCase()
+        )
         return acc.concat(highlight)
       }, [])
       return highlights
@@ -247,12 +257,14 @@ class ProductDetails extends Component {
       return highlights
     }
 
-    switch (choose){
-      case 'editor.product-details.highlights.chooseDefault': return highlightsFromGroup()
-      case 'editor.product-details.highlights.chooseDefaultSpecification': return highlightsFromSpecifications()
-      case 'editor.product-details.highlights.allSpecifications': return highlightsFromAllSpecifications()
+    switch (choose) {
+      case 'editor.product-details.highlights.chooseDefault':
+        return highlightsFromGroup()
+      case 'editor.product-details.highlights.chooseDefaultSpecification':
+        return highlightsFromSpecifications()
+      case 'editor.product-details.highlights.allSpecifications':
+        return highlightsFromAllSpecifications()
     }
-
   }
 
   render() {
@@ -267,6 +279,7 @@ class ProductDetails extends Component {
       intl,
       showSpecificationsTab,
       showHighlight,
+      thumbnailPosition,
     } = this.props
     const { selectedQuantity } = this.state
 
@@ -362,6 +375,7 @@ class ProductDetails extends Component {
                     <ExtensionPoint
                       id="product-images"
                       images={this.getImages()}
+                      position={thumbnailPosition}
                     />
                   </div>
                 </div>
@@ -369,12 +383,12 @@ class ProductDetails extends Component {
               <aside
                 className={`${
                   productDetails.detailsContainer
-                  } pl8-l w-40-l w-100`}
+                } pl8-l w-40-l w-100`}
               >
                 <div
                   className={`${
                     productDetails.nameContainer
-                    } c-on-base dn db-l mb4`}
+                  } c-on-base dn db-l mb4`}
                 >
                   <ExtensionPoint id="product-name" {...productNameProps} />
                 </div>
@@ -411,7 +425,7 @@ class ProductDetails extends Component {
                     <div
                       className={`${
                         productDetails.priceContainer
-                        } pt1 mt mt7 mt4-l dn-l`}
+                      } pt1 mt mt7 mt4-l dn-l`}
                     >
                       <ExtensionPoint
                         id="product-price"
@@ -426,13 +440,13 @@ class ProductDetails extends Component {
                       </ExtensionPoint>
                     </div>
                   ) : (
-                      <div className="pv4">
-                        <ExtensionPoint
-                          id="availability-subscriber"
-                          skuId={this.selectedItem.itemId}
-                        />
-                      </div>
-                    )}
+                    <div className="pv4">
+                      <ExtensionPoint
+                        id="availability-subscriber"
+                        skuId={this.selectedItem.itemId}
+                      />
+                    </div>
+                  )}
                   <FixedButton>
                     <div className="dn-l bg-base w-100 ph5 pv3">
                       <ExtensionPoint id="buy-button" {...buyButtonProps}>
@@ -478,7 +492,7 @@ class ProductDetails extends Component {
             <div
               className={`flex ${
                 showSpecificationsTab ? 'flex-wrap' : 'justify-between'
-                }`}
+              }`}
             >
               {description && (
                 <div className="pv2 mt8 h-100 w-100">
@@ -561,11 +575,14 @@ ProductDetails.getSchema = props => {
               {
                 properties: {
                   highlight: {
-                    enum: ['editor.product-details.highlights.chooseDefaultSpecification'],
+                    enum: [
+                      'editor.product-details.highlights.chooseDefaultSpecification',
+                    ],
                   },
                   typeSpecifications: {
                     type: 'string',
-                    title: 'editor.product-details.highlights.typeSpecifications.title',
+                    title:
+                      'editor.product-details.highlights.typeSpecifications.title',
                   },
                 },
                 required: [''],
@@ -579,12 +596,19 @@ ProductDetails.getSchema = props => {
       conditional: {
         title: 'Conditional',
         $ref: '#/definitions/highlightGroupDefault',
-
       },
       showHighlight: {
         type: 'boolean',
         title: 'editor.product-details.showHighlight.title',
         default: true,
+        isLayout: false,
+      },
+      thumbnailPosition: {
+        title: 'editor.product-details.thumbnailsPosition.title',
+        type: 'string',
+        enum: getThumbnailsPositionValues(),
+        enumNames: getThumbnailsPositionNames(),
+        default: thumbnailsPosition.DISPLAY_LEFT.value,
         isLayout: false,
       },
     },

--- a/react/utils/thumbnailPositionEnum.js
+++ b/react/utils/thumbnailPositionEnum.js
@@ -1,0 +1,22 @@
+import { values, map } from 'ramda'
+
+const thumbnailsPosition = {
+  DISPLAY_LEFT: {
+    name: 'editor.product-details.thumbnailsPosition.left',
+    value: 'left',
+  },
+  DISPLAY_RIGHT: {
+    name: 'editor.product-details.thumbnailsPosition.right',
+    value: 'right',
+  },
+}
+
+export function getThumbnailsPositionNames() {
+  return map(opt => opt.name, values(thumbnailsPosition))
+}
+
+export function getThumbnailsPositionValues() {
+  return map(opt => opt.value, values(thumbnailsPosition))
+}
+
+export default thumbnailsPosition


### PR DESCRIPTION
#### What is the purpose of this pull request? #### What problem is this solving?

Add the customization to the thumbnails image position on the storefront.

#### How should this be manually tested?

[Access](https://imageposition--storecomponents.myvtex.com/admin/cms/storefront); enter on a product with thumbnails; Go to product details section and change "Thumbnails position"

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
