### PR TITLE
Passing imageUrl prop to share

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.12.1] - 2019-04-09
+
 ### Added
 
 - Pass imageUrl prop to `Share`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,38 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [1.12.0] - 2019-04-08
 ### Added
-- Thumbnails position on storefront. 
+
+- Pass imageUrl prop to `Share`.
+
+## [1.12.0] - 2019-04-08
+
+### Added
+
+- Thumbnails position on storefront.
 
 ## [1.11.2] - 2019-04-02
+
 ### Fixed
-- Improve `product-highlights` schema. 
+
+- Improve `product-highlights` schema.
 
 ## [1.11.1] - 2019-03-27
+
 ### Fixed
+
 - Remove `product-highlights` as a required block.
 
 ## [1.11.0] - 2019-03-27
+
 ### Added
-- Add `ProductHighlights` component. 
+
+- Add `ProductHighlights` component.
 
 ## [1.10.7] - 2019-03-14
+
 ### Changed
+
 - Change basic language files names.
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "product-details",
   "vendor": "vtex",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "title": "Product Details",
   "description": "Product details component",
   "defaultLocale": "pt-BR",

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -344,6 +344,7 @@ class ProductDetails extends Component {
       installments: path(['Installments'], this.commertialOffer),
       ...this.props.price,
     }
+    const productImageUrl = path(['items', 0, 'images', 0, 'imageUrl'], product)
 
     const availableQuantity = path(['AvailableQuantity'], this.commertialOffer)
     const showProductPrice =
@@ -467,6 +468,7 @@ class ProductDetails extends Component {
                       id="share"
                       shareLabelClass="c-muted-2 t-small mb3"
                       className="db"
+                      imageUrl={productImageUrl}
                       {...this.props.share}
                       loading={!path(['name'], this.selectedItem)}
                       title={intl.formatMessage(


### PR DESCRIPTION
#### What is the purpose of this pull request?

Passing imageUrl prop to share component for pinterest option works.

#### What problem is this solving?

Add one more option on share. Depends on [this](https://github.com/vtex-apps/store-components/pull/405) PR

#### How should this be manually tested?

[Access](https://theo--storecomponents.myvtex.com/)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
