### PR TITLE
Remove duplicate productView events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Forwards categoryTree prop to breadcrumb
 
-## [1.17.0] - 2019-05-02
+## [1.17.0] - 2019-05-02 [YANKED]
 ### Added
 - Send produdcView events to Pixel Manager.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.18.1] - 2019-05-09
+
 ### Fixed
 - Remove `productView` event added in v1.17.0.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Remove `productView` event added in v1.17.0.
+
 ## [1.18.0] - 2019-05-07
 ### Changed
 - Forwards categoryTree prop to breadcrumb
 
 ## [1.17.0] - 2019-05-02 [YANKED]
 ### Added
-- Send produdcView events to Pixel Manager.
+- Send `productView` event to Pixel Manager.
 
 ## [1.16.0] - 2019-04-29
 ### Add

--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,6 @@
     "vtex.breadcrumb": "1.x",
     "vtex.store-graphql": "2.x",
     "vtex.store-components": "3.x",
-    "vtex.styleguide": "9.x",
-    "vtex.pixel-manager": "0.x"
+    "vtex.styleguide": "9.x"
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "product-details",
   "vendor": "vtex",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "title": "Product Details",
   "description": "Product details component",
   "defaultLocale": "pt-BR",

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -17,7 +17,6 @@ import { injectIntl, intlShape, FormattedMessage } from 'react-intl'
 
 import { ExtensionPoint, withRuntimeContext } from 'vtex.render-runtime'
 import { Container } from 'vtex.store-components'
-import { Pixel } from 'vtex.pixel-manager/PixelContext'
 
 import { changeImageUrlSize } from './utils/generateUrl'
 import FixedButton from './components/FixedButton'
@@ -171,13 +170,13 @@ class ProductDetails extends Component {
 
     return images
       ? images.map(image => ({
-        imageUrls: imageSizes.map(size =>
-          changeImageUrlSize(image.imageUrl, size)
-        ),
-        thresholds,
-        thumbnailUrl: changeImageUrlSize(image.imageUrl, thumbnailSize),
-        imageText: image.imageText,
-      }))
+          imageUrls: imageSizes.map(size =>
+            changeImageUrlSize(image.imageUrl, size)
+          ),
+          thresholds,
+          thumbnailUrl: changeImageUrlSize(image.imageUrl, thumbnailSize),
+          imageText: image.imageText,
+        }))
       : []
   }
 
@@ -199,17 +198,6 @@ class ProductDetails extends Component {
       specifications,
       highlights,
     }
-  }
-
-  sendPixelEvents() {
-    this.props.push({
-      event: 'productView',
-      items: this.props.productQuery.product,
-    })
-  }
-
-  componentDidMount() {
-    this.sendPixelEvents()
   }
 
   getHighlights() {
@@ -400,12 +388,12 @@ class ProductDetails extends Component {
               <aside
                 className={`${
                   productDetails.detailsContainer
-                  } pl8-l w-40-l w-100`}
+                } pl8-l w-40-l w-100`}
               >
                 <div
                   className={`${
                     productDetails.nameContainer
-                    } c-on-base dn db-l mb4`}
+                  } c-on-base dn db-l mb4`}
                 >
                   <ExtensionPoint id="product-name" {...productNameProps} />
                 </div>
@@ -442,7 +430,7 @@ class ProductDetails extends Component {
                     <div
                       className={`${
                         productDetails.priceContainer
-                        } pt1 mt mt7 mt4-l dn-l`}
+                      } pt1 mt mt7 mt4-l dn-l`}
                     >
                       <ExtensionPoint
                         id="product-price"
@@ -452,7 +440,7 @@ class ProductDetails extends Component {
                   )}
                   {showBuyButton ? (
                     <div className="pv2 dn db-l mt8">
-                      <ExtensionPoint
+                      <ExtensionPoint 
                         id="product-quantity-selector"
                         selectedQuantity={selectedQuantity}
                         onChange={value => this.setState({ selectedQuantity: value })}
@@ -463,13 +451,13 @@ class ProductDetails extends Component {
                       </ExtensionPoint>
                     </div>
                   ) : (
-                      <div className="pv4">
-                        <ExtensionPoint
-                          id="availability-subscriber"
-                          skuId={this.selectedItem.itemId}
-                        />
-                      </div>
-                    )}
+                    <div className="pv4">
+                      <ExtensionPoint
+                        id="availability-subscriber"
+                        skuId={this.selectedItem.itemId}
+                      />
+                    </div>
+                  )}
                   <FixedButton>
                     <div className="dn-l bg-base w-100 ph5 pv3">
                       <ExtensionPoint id="buy-button" {...buyButtonProps}>
@@ -516,7 +504,7 @@ class ProductDetails extends Component {
             <div
               className={`flex ${
                 showSpecificationsTab ? 'flex-wrap' : 'justify-between'
-                }`}
+              }`}
             >
               {description && (
                 <div className="pv2 mt8 h-100 w-100">
@@ -544,13 +532,7 @@ class ProductDetails extends Component {
   }
 }
 
-const ProductDetailsWithPixel = compose(
-  Pixel,
-  withRuntimeContext,
-  injectIntl
-)(ProductDetails)
-
-ProductDetailsWithPixel.getSchema = props => {
+ProductDetails.getSchema = props => {
   return {
     title: 'admin/editor.product-details.title',
     description: 'admin/editor.product-details.description',
@@ -656,4 +638,4 @@ function mergeSchemaAndDefaultProps(schema, propName) {
   })
 }
 
-export default ProductDetailsWithPixel
+export default withRuntimeContext(injectIntl(ProductDetails))

--- a/react/__mocks__/vtex.pixel-manager/PixelContext.js
+++ b/react/__mocks__/vtex.pixel-manager/PixelContext.js
@@ -1,9 +1,0 @@
-import React from 'react'
-
-export function Pixel(Comp) {
-  return class extends React.Component {
-    render() {
-      return <Comp {...this.props} />
-    }
-  }
-}

--- a/react/__tests__/ProductDetails.test.js
+++ b/react/__tests__/ProductDetails.test.js
@@ -22,7 +22,6 @@ describe('<ProductDetails /> component', () => {
       productQuery: {
         loading: true,
       },
-      push: (args) => { }
     }
 
     const render = getComponentRender(props)
@@ -37,7 +36,6 @@ describe('<ProductDetails /> component', () => {
         loading: false,
         product: getProduct(),
       },
-      push: (args) => { }
     }
 
     const render = getComponentRender(props)
@@ -52,7 +50,6 @@ describe('<ProductDetails /> component', () => {
         loading: false,
         product: getProduct(),
       },
-      push: (args) => { }
     }
 
     const { container } = getComponentRender(props)
@@ -68,7 +65,6 @@ describe('<ProductDetails /> component', () => {
         loading: false,
         product: getProduct(),
       },
-      push: (args) => { }
     }
 
     const { container } = getComponentRender(props)


### PR DESCRIPTION
#### What is the purpose of this pull request?

This reverts commit 4805e2c92be54211f1c7cecd14b93556ef53c30d, reversing
changes made to 29063e3028d7c30d0712450d9f3e57b340142886.

#### What problem is this solving?

The `productView` event is already being sent by [ProductWrapper](https://github.com/vtex-apps/store/blob/master/react/ProductWrapper.js#L100-L101). 

#### How should this be manually tested?

https://googleanalytics--storecomponents.myvtex.com/traveler-backpack/p

#### Screenshots or example usage

n/a

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
