### PR TITLE
Hotfix/empty product query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.18.5] - 2019-05-26
 ### Fixed
 - Prevent from throwing errors when ProductQuery is empty for some reason on ProductDetails
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prevent from throwing errors when ProductQuery is empty for some reason on ProductDetails
 
 ## [1.18.4] - 2019-05-24
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "product-details",
   "vendor": "vtex",
-  "version": "1.18.4",
+  "version": "1.18.5",
   "title": "Product Details",
   "description": "Product details component",
   "defaultLocale": "pt-BR",

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,6 @@
     "vtex.store-graphql": "2.x",
     "vtex.store-components": "3.x",
     "vtex.styleguide": "9.x"
-  }
+  },
+  "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -259,12 +259,8 @@ class ProductDetails extends Component {
       thumbnailPosition,
     } = this.props
 
-    const product = productQuery && productQuery.product
+    const product = productQuery ? productQuery.product : {}
     
-    if (!product) {
-      return null
-    }
-
     const { selectedQuantity } = this.state
 
     const showBuyButton =

--- a/react/ProductDetails.js
+++ b/react/ProductDetails.js
@@ -245,7 +245,7 @@ class ProductDetails extends Component {
 
   render() {
     const {
-      productQuery: { product },
+      productQuery,
       categories,
       categoryTree,
       runtime: {
@@ -258,6 +258,13 @@ class ProductDetails extends Component {
       showHighlight,
       thumbnailPosition,
     } = this.props
+
+    const product = productQuery && productQuery.product
+    
+    if (!product) {
+      return null
+    }
+
     const { selectedQuantity } = this.state
 
     const showBuyButton =


### PR DESCRIPTION
#### What is the purpose of this pull request?
Prevent ProductDetails from crashing when ProductQuery is empty for some reason

Before: (**console open, and beware that it might crash**) https://invictastores.myvtex.com/invicta-pro-diver-mens-quartz-48-mm-gold-case-black-dial---model-30060/p

After: https://lbebber--invictastores.myvtex.com/invicta-pro-diver-mens-quartz-48-mm-gold-case-black-dial---model-30060/p

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
